### PR TITLE
chore(arch): 落地迁移前防腐基线与坏味道防线

### DIFF
--- a/.agents/skills/rust-quant-architecture/SKILL.md
+++ b/.agents/skills/rust-quant-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-quant-architecture
-description: 约束 rust_quant 的领域归属、代码放置、数据库 CRUD、Ports/Adapters、Research/回测和生产运行边界。用于设计、评审、实现或迁移后端模块、Vegas、策略/组合/风险/执行链路、分级模拟、运行入口和架构文档，以及检查代码是否违反目标架构。
+description: 约束 rust_quant 的领域归属、代码放置、数据库 CRUD、Ports/Adapters、Research/回测和生产运行边界。用于设计、评审、实现或迁移后端模块、Vegas、策略/组合/风险/执行链路、分级模拟、运行入口和架构文档，检查代码是否违反目标架构，以及识别并防止六类结构坏味道（空 struct 服务、指标层做决策、同名两义配置、依赖反向拉直连、env flag 热路径、时间戳内联）、七类工程纪律坏习惯（f64 金额、无类型 JSON 端口、SDK DTO 穿透、热路径 panic、压平错误、pub 泛滥、假测试）、八类基础设施/数据/运维坏习惯（fire-and-forget spawn、schema 三真相源、迁移改写、密钥裸传、配置散读、无可观测性、依赖不复用、契约无版本）与研究/生产未隔离。
 ---
 
 # Rust Quant 架构规范
@@ -26,7 +26,7 @@ description: 约束 rust_quant 的领域归属、代码放置、数据库 CRUD�
 | 业务逻辑、CRUD、SQL、事务、Consumer | [业务代码与数据访问](../../../docs/architecture/business-code-and-data-access.md)、[ADR-0007](../../../docs/architecture/adr/0007-owner-scoped-persistence-and-transaction-boundaries.md) |
 | Research、Vegas、回测或模拟交易 | [ADR-0009](../../../docs/architecture/adr/0009-research-domain-and-tiered-simulation.md)、[Vegas 迁移实战](../../../docs/architecture/vegas-backtest-migration.md)、[通用量化逻辑归属](../../../docs/architecture/common-logic-placement.md) |
 | Worker、订单、保护单、对账与恢复 | [生产运行与恢复](../../../docs/architecture/production-runtime.md)、[ADR-0004](../../../docs/architecture/adr/0004-portfolio-and-trading-domain-boundaries.md)、[ADR-0006](../../../docs/architecture/adr/0006-at-least-once-idempotency-and-recovery.md) |
-| 新增代码、迁移 legacy、架构 Review | [AI 架构护栏](../../../docs/architecture/ai-coding-guardrails.md)、[迁移计划](../../../docs/architecture/migration-plan.md) |
+| 新增代码、迁移 legacy、架构 Review | [AI 架构护栏](../../../docs/architecture/ai-coding-guardrails.md)、[AI 迁移执行协议](../../../docs/architecture/ai-migration-execution-protocol.md)、[迁移计划](../../../docs/architecture/migration-plan.md) |
 
 ADR-0008 只保留为决策历史。遇到 Research 或 backtest 设计冲突时，以 ADR-0009 为准。
 
@@ -35,6 +35,8 @@ ADR-0008 只保留为决策历史。遇到 Research 或 backtest 设计冲突时
 ### 1. 明确任务边界
 
 区分分析、诊断、设计、修改、迁移和运行态验证；分析/诊断保持只读，实盘 mutation 必须取得明确授权。先声明假设、歧义和成功标准；存在多个合理 owner 或会改变产品语义时，停止并说明选择影响。
+
+legacy、crate、Owner、事实源、运行入口或 Backtest/Live 双实现迁移必须先创建 Migration Manifest，锁定已提交架构基线、单一迁移模式、允许路径、业务不变量、验证和删除门。聊天计划不能替代 Manifest；diff 越界、模式混合、基线漂移或需要未授权 cutover 时立即停止。
 
 ### 2. 提交代码放置声明
 
@@ -60,7 +62,7 @@ Adapters：
 
 ### 3. 从真实调用链反向验证
 
-使用当前代码、测试、数据库 contract 和运行入口复核假设。标记 legacy 边界，不把历史目录当成目标 owner。
+使用当前代码、测试、数据库 contract 和运行入口复核假设。标记 legacy 边界，不把历史目录当成目标 owner。对照“迭代废物的产生模式”“工程纪律坏习惯”“基础设施/数据/运维纪律坏习惯”三节自查：新增代码是否在复制任一坏味道/坏习惯，触碰的存量属于哪一类、收敛路径是什么。
 
 对 Vegas 或回测至少追踪：
 
@@ -148,6 +150,64 @@ EvaluationScopeId + StrategyRuntimeSnapshotId + MarketStreamPartition
 - 未经明确授权，不下单、撤单、平仓或修改交易所账户。
 - 实盘订单必须先验证凭证、权限、symbol filters、数量精度、风险、worker lease 和保护单计划；没有止损不允许下单。
 - 研究收益、胜率、Sharpe、回撤和 PnL 必须带数据范围、版本、费用、滑点、资金费和时序证据。
+
+## 迭代废物的产生模式与新架构防线
+
+以下六个坏味道是 legacy Core 在反复迭代 / 策略调参中真实滚雪球形成的，均有 `dependency-rules.md` §13 对应条款。写新代码、评审或迁移时，**先自查是否在复制这些模式**；发现存量按“最小修订方案”给出收敛路径，不就地扩大。
+
+| # | 坏味道模式（当初的“图快”动机） | 存量证据 | 违反 | 新架构防线 |
+| --- | --- | --- | --- | --- |
+| 1 | **空 struct 冒充服务**：迁 legacy 自由函数时统一包 `pub struct XxxService;` + 一堆 async fn，零字段 | 22 个零字段 `*Service/*Manager/*Calculator`；`services/market/` 下 8 个同构文件；`risk_management_service.rs` 方法体是 TODO 占位 | §13.18 / §11 | 无状态逻辑是 use case 函数或 Policy；不为“命名”造类型。只有持有 Port/配置快照才允许成对象 |
+| 2 | **指标旁边就地做决策**：指标迭代中就地写开平仓判断，滚成隐藏策略引擎并反向 `use domain` | `indicators/trend/vegas/strategy/` 11572 行；`trade_signal.rs` 直接产 `should_buy/stop_loss_price`；`indicators` 21 处 `use rust_quant_domain` | §3 / §13.11 | owner-agnostic 层（`quant/*`）零业务 Domain 依赖；`SignalResult` 等决策产物只能在 Strategy Domain 生产 |
+| 3 | **同名两义配置**：domain 有一份配置，加字段嫌麻烦就在别处另起同名 struct，用 `pub use as` 别名互相掩盖 | `BasicRiskStrategyConfig` domain 版 7 字段 vs strategies 版 20+ 字段；账户字段 `account_risk_fraction_per_trade`/`position_leverage` 穿透进 `get_trade_signal` 入参 | §13.13 / §13.20 / §13.25 | 一个 JSON = 一个 owner = 一个类型；evaluator 入参禁含账户资金 / 用户风险 / 最终数量口径字段 |
+| 4 | **依赖箭头图省事拉直连**：要复用就直接加 Cargo 依赖，跳过 domain 抽象；下单直接 `use okx` 裸 SDK | `execution` 依赖 strategies/indicators/risk 却不依赖 domain（V2）；`swap_order_service.rs` 直调 `OkxApiTrait` mutation | §3 / §13.17 | 执行层只依赖 `domain::ports` 与上游 api；mutation capability 只进 Fenced Gateway，App/Dispatcher 不装配 raw SDK client |
+| 5 | **env flag 当临时开关不回收**：调策略行为直接加 `VEGAS_XXX` env “临时”验证，验证完不删 | 决策热路径 40+ 个 `VEGAS_*` env，每次现读 `std::env::var`（`long_rule_helpers`/`short_rule_helpers`） | §13.4 / §13.27 | 决策开关是带规范 hash 的显式配置输入；非 App/Platform 禁读 env；热路径禁读 env / “最新版本” / 隐式默认 |
+| 6 | **时间戳写死在 mutate 方法**：聚合根每个状态迁移内联 `Utc::now()` | `order.rs`/`position.rs`/`strategy_config.rs` 数十处；策略信号 `signal.ts = Utc::now()` | §13.19 | Model/Policy 注入 `Clock` Port；decision-time 由上游传入，回测/live 用同一注入时钟保 parity |
+
+## 工程纪律坏习惯（编码级，同样在新架构堵住）
+
+结构坏味道之外的另一批，危害集中在**资金精度、类型安全、实盘 panic**三处。根节点是「边界懒得建映射层」——A/B/C 同源：Domain 用 f64 与 `serde_json::Value` 定义、SDK DTO 一路透传，导致类型安全和资金精度在最该强的交易/订单路径反而最弱。对应目标架构 §10 / §10.1 / §10.2 / §12。
+
+| 键 | 坏习惯 | 存量证据 | 新架构防线 |
+| --- | --- | --- | --- |
+| A | **f64 做金额，从 domain 向上污染** | 110 处金额 f64 字段；risk/execution 对 Decimal 引用为 **0**（全 f64），services 已用 Decimal → 混用带；`position.rs` 实体 pnl/margin 即 f64；`breakeven_stop_loss.rs:213` 止损价 f64 | 金额在 **Domain 层就用 Decimal 定义**；止损价/下单量/保证金率全程 Decimal，禁 f64 中间态（§10） |
+| B | **domain 端口返回 `serde_json::Value`** | `exchange_trait.rs` 7 处端口吐无类型 JSON；全库 473 处 Value 当万能类型；实体裸 Value 字段 | Port 用领域类型命名；无类型 JSON 只在 Adapter 内部与 Contract wire 层；存证用命名 `raw_payload` 且不参与决策（§10.1） |
+| C | **SDK DTO / DB Row 穿透业务层** | `okx::dto::*` 63 处；execution 直接吃 `okx::dto::account_dto::Position`；market 把 `CandleOkxRespDto` 当内部模型 | SDK DTO 只在 exchange-gateway 映射，Row 只在 Postgres Adapter 映射；业务 crate 禁 `use okx::*`/sqlx Row（§10.1） |
+| D | **热路径 unwrap，全在实盘链** | `swap_order_service.rs:309` 下单量 `.unwrap()`；`swap_order.rs:54` 订单 key `split.nth(0).unwrap()`；`gateway.rs:761` 用 `panic!` 表达未支持交易所 | 交易/执行/风控热路径禁 unwrap/expect/panic；未支持分支返回 `Err` 并 fail-closed（§10.2） |
+| E | **压平错误换“能跑”** | `unwrap_or_default()` services 74 处 → 失败余额静默变 `0.0` 令风控误判无仓位；`scheduler_service.rs:84` 关停/join 结果 `let _ =` 丢弃 | 金额/仓位 Result 必须传播由 Use Case 决定 fail-closed；后台任务失败必须被感知记录（§10.2） |
+| F | **默认全 pub，可见性零收敛** | domain 294 pub / **0 pub(crate)**；全库 pub:pub(crate)≈7:1；371 处 re-export；439 处 glob import | Domain/业务 crate 对外只经 `api`/`lib.rs` 出口；内部 `pub(crate)` 或私有；禁 `pub mod` 全敞开 + glob re-export（§12） |
+| G | **研究脚本固化成 #[ignore] 假测试** | 60 处 `#[ignore]`（`scalper_research.rs` 单文件 19 个）；根 `tests/` 大量 0 断言只 println；111 文件连真实 PG、46 打真实 OKX | 测试确定性 + 有断言；参数扫描/探索归 `examples/`；依赖真实基础设施的测试归 integration，不作默认 CI 门禁（§12） |
+
+次要但要盯：粗粒度 `Arc<Mutex<整块状态>>` 跨 await 持有（`deep_stream_manager`、全局 `SCHEDULER` 把并发退化为串行 → 拆状态粒度或消息传递/`ArcSwap`）；MVP 硬编码沉淀为业务规则（ETH-only 白名单写死进 execution、风控阈值写死进 `Default` → 走配置）；注释即删除（execution 成段 `// let` 旧逻辑 → 删掉靠 git 找回）。
+
+## 基础设施/数据/运维纪律坏习惯（第三批，迁移期尤其致命）
+
+危害集中在**数据一致性、可复现构建、密钥安全、静默失败**，H/J/O 直接影响迁移期环境重建。对应目标架构 §10.3 / §12 / production-runtime §11-13。三个贯穿性根因：①正例存在但未强制下沉（`task_scheduler`/`websocket_service` 会正确 join+abort，新代码却仍 fire-and-forget）；②平台迁移未收尾（MySQL→Postgres 旧债不回填，靠"当前库已是目标态"掩盖）；③静默失败链（fire-and-forget + 无 metrics + 无 health + span 不贯穿 = 进程活着但业务停摆，监控看不见）。
+
+| 键 | 坏习惯 | 存量证据 | 新架构防线 |
+| --- | --- | --- | --- |
+| H | **fire-and-forget spawn** | 48 处 spawn，生产约 20 处丢 JoinHandle；`bootstrap.rs:152-524` worker/雷达/同步循环无句柄；K线 upsert spawn 失败静默丢写 | 统一 task supervisor（JoinSet/结构化并发），禁裸 spawn 丢句柄；任务失败必须被感知记录（§12） |
+| I | **schema 三套真相来源** | migrations 40 表 / `sql/postgres_quant_core.sql` 44 表 / 运行时 DDL（candle/backtest repo）并存，44≠40，靠 contract test `.contains()` 硬顶 | 表结构只由 `migrations/` 定义，禁运行时 DDL 与旁路整库脚本；分表用声明式分区/统一注册器（§10.3） |
+| J | **历史迁移改写 + 不可重放** | 3+ 处已应用迁移被后续 commit 重写（checksum 崩）；8 个迁移含 MySQL 语法从零重放必炸；无 down | 迁移严格 append-only、可空库重放、清理不可移植语法、提供回滚；新表新列带 COMMENT（§10.3） |
+| K | **密钥当普通数据传** | 51 处密钥裸 `String`；`ExchangeApiConfig` 在 domain `derive(Debug,Serialize)`+明文 secret；穿透 web contract；`local-dev-secret` 进部署脚本 | 凭证用 redacting 包装类型（脱敏 Debug、禁默认 Serialize），不进 Domain/Contract；内部 secret 无安全默认值，缺失 fail-closed（§10.3） |
+| L | **配置去中心化到极致** | 616 次 `env::var` × 163 文件；无类型化 Config；无 `.env.example`；同变量多处默认值不一致 | App/Platform 集中解析强类型 Config 注入；业务 crate 不散读 env；单一登记处 + 配置清单（§10.3） |
+| M | **无 metrics / 无 health / span 不贯穿** | prometheus/otel 命中 0；`#[instrument]` 仅 2 处；只有 DB `health_check()`，无 `/health`；错误无统一 `ErrorKind` | 关键路径（下单/成交/对账/lease/readiness）埋 metrics + 贯穿 span + 标准 `/health`；错误分类 Retryable/Fatal（§12） |
+| N | **有依赖不复用，各写各的** | 依赖 `tokio-retry` 却手写 6+ 套重试（99 处）；幂等键分散；`hyperliquid_rust_sdk` git 无 rev（不可复现） | 统一 retry/退避/去重封装；workspace 内 `workspace = true`；git 依赖钉 rev（§12） |
+| O | **同表多套 Row + 表名漂移** | `SwapOrderEntity` 定义 3 次跨 3 crate；`CandlesEntity` 2 次；`strategy_config` vs `strategy_configs` 并存 | 一表一 `FromRow` 归属其 owner Adapter；表名集中常量，不留旧名别名（§10.3） |
+| P | **契约无版本化** | internal HTTP API 无 `/v1/`、无 apiVersion；版本混进业务字符串 `entry_rule_version:"..._v2"`；必填字段无 `#[serde(default)]` | internal API 显式版本化，可选字段带 default 兼容，版本不混业务字符串；handoff/Outbox N/N-1（§7.3/§12） |
+
+## 研究/迭代与生产必须物理隔离
+
+上面六个坏味道之外，**最大的永久废物来源是“研究试错的沉渣堆进了生产代码仓”**。存量：4–5 套并行回测实现（`framework/backtest` 活，`orchestration/backtest`、`risk/backtest`、`cli/market_velocity_event_backtest` 40K 行自建、`btc_eth_strategy_family` 各重造）；策略版本以文件演进（`filtered_volume_rsi_ema_macd/` v1→v13、docs `V10→V27`、vegas `V61→V77`）；83 个 `src/bin/` 里 39 个是一次性 research/probe，与 8 个生产 `quant_core_*_worker` 混住；188 个 docs（136 个 `*_MANIFEST.md`）大量未跟踪。
+
+新架构强制规则：
+
+1. **策略版本走配置不走文件**：策略即数据（参数化 + registry），新版本 = 新 `version`/`strategy_key` + 配置，不复制源文件。禁止 `*_v2`/`*_v13` 命名的策略源文件家族。
+2. **单一回测引擎**：所有研究入口复用 `quant/backtest` 的确定性时钟/事件调度/撮合/费用/滑点/资金费，不在 CLI 或其它 crate 重造 equity/PnL/撮合。
+3. **研究 bin 剥离**：一次性 research/panel/probe 入口归 `apps/quant-lab` 与 Research Domain，不进 `core-runtime` 镜像依赖图（§13.23/24）。生产 `src/bin/` 只留生产角色 worker。
+4. **研究产物不进代码仓**：`*_MANIFEST.md`/`*_EVALUATION.md`/`_RESULT.md` 与跑批输出写 gitignore 的 artifacts 目录；进仓的只有 Completed ResearchEvidence 的稳定引用。
+5. **一次性脚本用完即删**：`fix_*.sh`/`migrate_phase*.sh` 这类迁移脚本完成后删除，不沉淀为永久噪声。
+6. **禁 Python 研究栈进主线**：迭代/回测禁用 Python（见 CLAUDE.md）；并行的 `.py`/`.mjs` 研究脚本不作为事实源。
 
 ## Review 输出格式
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6651,6 +6651,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "toml",
+]
+
+[[package]]
 name = "yaml-rust2"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/orchestration",
     "crates/analytics",
     "crates/rust-quant-cli",
+    "xtask",                 # 架构防腐检查器(只读,不进生产依赖图)
 ]
 resolver = "2"
 
@@ -129,7 +130,6 @@ rust-quant-risk = { path = "crates/risk" }
 rust-quant-execution = { path = "crates/execution" }
 rust-quant-orchestration = { path = "crates/orchestration" }
 rust-quant-analytics = { path = "crates/analytics" }
-rust-quant-ai-analysis = { path = "crates/ai-analysis" }
 rust-quant-cli = { path = "crates/rust-quant-cli" }
 crypto_exc_all = { path = "../crypto_exc_all" }
 

--- a/docs/architecture/dependency-rules.md
+++ b/docs/architecture/dependency-rules.md
@@ -2,7 +2,7 @@
 
 - 状态：已接受
 - 首次接受：2026-07-18
-- 最近修订：2026-07-21
+- 最近修订：2026-07-23
 - 上位文档：[Rust Quant 长期目标架构](target-architecture.md)
 - CRUD 细则：[业务代码与数据访问放置规范](business-code-and-data-access.md)
 
@@ -196,6 +196,21 @@ Use case 可以定义事务必须原子完成哪些业务结果，但不能接�
 - SimulationLedger 不是 AccountProjection，模拟事实不得写生产 Order/Fill/Account 表；
 - Evidence 使用内容寻址对象加 Research owner 数据库事务实现原子可见发布，不宣称跨存储全局原子。
 
+### 5.9 Rust 对象、函数与 Trait
+
+代码形态不能替代 owner 和分层。新增代码按以下规则选择：
+
+- 有稳定业务 identity、生命周期或必须一起维护的不变量，使用 Entity/Aggregate `struct`/`enum` + `impl`；
+- 只有单位、范围、组合合法性而无 identity，使用不可变 Value Object；
+- 无状态、无 I/O、完整输入决定输出，默认使用 module 内自由纯函数；
+- 多个纯决策共享同一不可变版本配置，使用 Policy 对象；Policy 的字段只能是已解析的强类型快照或纯依赖；
+- 跨市场事件维护滚动状态时，使用带完整 scope identity 的显式 State，并让 backtest/live 调用同一纯 transition；
+- Use Case 可以是持有 Port 的对象；没有状态和依赖时，不得仅为了 `XxxService::method()` 语法创建零字段 Service；
+- Adapter 可以持有连接池、Client、限流器和协议配置，但不得因此接管业务不变量；
+- Trait 只用于真实多实现、消费方 Port、稳定 Domain API 或测试替身，不建立继承式 `BaseService`、万能 `Manager` 或每类型一个空 Trait。
+
+Aggregate 中能够破坏不变量的字段不得向任意调用方公开可变访问；时间、随机值和外部事实必须作为参数或 Port 输入。把一个跨 owner 大函数移动到 `impl TradingState`、`TradingEngineService` 或其他对象中，不会改变其违规性质。
+
 ## 6. Owner 规则
 
 | 事实 | 唯一 Owner |
@@ -242,6 +257,52 @@ Use case 可以定义事务必须原子完成哪些业务结果，但不能接�
 
 只有独立轮询/流消费、扩缩容、故障隔离、安全边界或部署生命周期出现时才创建 App。文件数量增加本身不是拆 App 的理由。
 
+### 8.1 构建与发布影响边界
+
+目标使用三个 Release Unit：
+
+| Release Unit | 内容 | 生产部署资格 |
+| --- | --- | --- |
+| `core-runtime` | control-api、market-worker、signal-worker、account-worker、execution-worker、reconciliation-worker | 自动发布候选 |
+| `core-maintenance` | schema-tool 与批准的有界维护 Job | 仅显式运行 |
+| `quant-lab` | Research、Backtest、Analytics、PaperEvent 研究入口和 research CLI | 禁止生产部署 |
+
+每个生产 App 是独立 Cargo package，但六个生产 binary 继续共享一个 `core-runtime` 镜像。Release Unit 是构建/工件边界，不是业务 owner、服务或仓库边界。
+
+目标依赖图必须保证：
+
+```text
+apps/signal-worker、apps/execution-worker
+  -> strategy-api + strategy-released
+  -> other production domains + quant/math/indicators + required adapters
+  -X-> strategy-candidates、domains/research、quant/backtest、quant/analytics、apps/quant-lab
+
+apps/quant-lab
+  -> strategy-api + strategy-released + strategy-candidates
+  -> domains/research
+  -> production domains stable APIs
+  -> quant/backtest/analytics/math
+```
+
+`release-units/{core-runtime,core-maintenance,quant-lab}.toml` 至少声明 root packages、binary allowlist、forbidden packages、镜像、生产部署资格和必需测试集。CI、Dockerfile、Compose 与 deploy contract 必须消费同一清单，不得各自维护一份二进制列表。
+
+CI/CD 通过 Git diff、owning package、`cargo metadata` 反向传递依赖和 Release Unit Manifest 计算影响范围。path filter 只能作为依赖图之上的优化，不能手工漏掉传递依赖；无法归属、依赖图失败或清单漂移时 fail closed：
+
+| 变更范围 | 必须构建/验证 |
+| --- | --- |
+| `apps/quant-lab`、`domains/research`、`quant/backtest`、`quant/analytics` | Research/quant-lab 单元、回放与 Evidence 测试；不因该变更重建生产 App |
+| Strategy owner 内的 `strategy-candidates` | 候选策略、quant-lab、Research 与候选回放；不构建生产 App |
+| Strategy owner 内的 `strategy-api`、`strategy-released` | signal-worker、依赖其公开 API 的生产 App、Research 与 parity |
+| Strategy、Portfolio、Risk、Execution、Market、`quant/math`、`quant/indicators` 的共享公开实现 | 所有受影响生产 App + Research + parity |
+| `apps/signal-worker` 或其专属装配 | signal-worker 与 deploy contract |
+| `apps/execution-worker`、生产 Execution Adapter/Contract | execution-worker、相关 consumer、contract、integration/recovery |
+| Contract 或共享 Platform API | 依赖该 Contract/API 的全部 producer/consumer |
+| Cargo.lock、toolchain、workspace/build script、Release Unit Manifest 或公共镜像基础 | 全部 Release Unit |
+
+新增“只用于实验、尚未发布”的候选策略，其规则仍由 Strategy owner 管理，但物理放入 `strategy-candidates`，并由 Research Experiment 引用；它不能注册进 live `StrategyCatalog` 或进入生产 App 依赖图。候选晋级时进入 `strategy-released` catalog，创建 Definition/Artifact/Release/RuntimeSnapshot，并重新进入生产构建、parity 和发布门禁。不能通过让生产 App 依赖回测 crate 来共享代码；已发布策略的共享业务逻辑只能位于 Strategy released/API 或其他对应 production Domain。
+
+生产镜像内容必须与 `core-runtime` binary allowlist 完全一致，禁止包含 quant-lab、Research/Backtest/optimizer、Paper 收益研究入口、strategy candidates、schema-tool 和未批准维护工具。每个工件记录 Git revision、Cargo.lock/toolchain、Manifest hash、传递依赖图 hash、binary checksum、镜像 digest 与 SBOM。完整规则见 [ADR-0010](adr/0010-build-impact-and-artifact-isolation.md)。
+
 ## 9. Contract 规则
 
 - 删除、改名或改变字段语义必须发布新版本；
@@ -251,7 +312,9 @@ Use case 可以定义事务必须原子完成哪些业务结果，但不能接�
 - 每个 Contract 有序列化快照、旧 payload 解析和未知字段测试；
 - Command/Event 携带 event、correlation、causation、idempotency、aggregate、sequence、时间和 partition identity；
 - producer 与所有 consumer 保持同一业务幂等身份；
-- consumer 在业务 side effect 与消费确认之间必须具备可恢复状态。
+- consumer 在业务 side effect 与消费确认之间必须具备可恢复状态；
+- `ExecutionRequest.risk_profile_ref/version` 只表达 Web 配置来源和授权；Core Risk 必须将其幂等解析为 Published `RiskPolicySnapshot`，缺失、不兼容或已撤销时 Blocked；
+- `ExecutionDecisionContextSnapshot` 必须带四个 Domain Policy Snapshot 的稳定 id/version/hash；后续 RiskDecision、OrderIntent、Plan、Attempt 与恢复 Contract 必须可追溯到同一 `context_id + context_hash`。
 
 ## 10. 数据库与事务规则
 
@@ -273,6 +336,8 @@ Use case 可以定义事务必须原子完成哪些业务结果，但不能接�
 - 时间和随机源必须注入；
 - backtest、paper、shadow、canary、live 复用同一业务实现；
 - Strategy evaluator 不接收账户风险配置；候选失效价可以作为信号证据，最终仓位、止损和审批由 Portfolio/Risk 决定；
+- `StrategyRuntimeSnapshot` 只包含 Strategy owner 事实，不包含 account、user、credential、risk profile 或 Portfolio/Risk/Execution policy 内容；
+- Portfolio、Risk、Execution planning 各自发布不可变 Policy Snapshot；Execution 只用 `ExecutionDecisionContextSnapshot` 绑定这些 Published 引用，不重新解析业务 JSON 或补默认值；
 - 已产生运行证据的策略 Definition/Artifact 不得覆盖；
 - Signal 携带 strategy version、definition hash 和 evidence cutoff；
 - PortfolioTarget 记录 allocator/policy version 与输入 Signal identity；
@@ -326,8 +391,20 @@ Use case 可以定义事务必须原子完成哪些业务结果，但不能接�
 15. ResearchBar 是否运行/声称覆盖 lease、outbox、Unknown 和 Reconciliation；
 16. ResearchEvidence 是否缺少原子可见发布状态或被 Strategy 表直接拥有。
 17. Dispatcher/其他 App 是否直接依赖或装配 raw SDK mutation client/credential；mutation capability 只能进入 Fenced Gateway。
+18. 新增零字段 `*Service`、`*Manager`、`*Calculator` 是否只作为 associated function 命名空间；
+19. Aggregate 是否公开能够绕过状态机或破坏不变量的可变字段，Model/Policy 是否直接读取系统时间、随机全局状态或进程全局业务缓存；
+20. backtest/live 是否新增重复的 Strategy、Portfolio、Risk、止盈止损或 OrderPlan 实现，或把同一 JSON 解析为语义重叠的运行模式配置；
+21. `signal-worker`、`execution-worker` 等生产 App 是否依赖 `strategy-candidates`、Research、`quant/backtest`、`quant/analytics` 或 `quant-lab`；
+22. CI 影响范围是否与 Cargo 传递依赖和 Release Unit Manifest 一致，Research-only 变更是否错误进入生产镜像，或共享 Domain 变更是否漏掉生产构建/parity；
+23. 生产镜像 binary 是否与 `core-runtime` allowlist 完全一致，是否混入 quant-lab、Research/Backtest/Paper、candidate、schema-tool 或未批准工具；
+24. 每个生产 App 是否为独立 Cargo package，且传递依赖闭包不含 candidates、Research、Backtest、Analytics；
+25. `StrategyRuntimeSnapshot` 是否混入 account/user/credential/risk profile 或其他 owner 的 policy 内容；
+26. Execution 是否在请求 intake 时原子持久化完整 `ExecutionDecisionContextSnapshot`，后续决策、计划、attempt 与恢复证据是否缺少 `context_id + context_hash`；
+27. 热路径是否重新读取可变配置、“最新版本”、环境变量或隐式默认值，ResearchRunSpec/Context 是否缺少规范 hash 与兼容测试。
 
 迁移期采用 ratchet：保存当前 legacy 违规基线，CI 只允许违规数下降，禁止新增。不得在门禁尚未实现时把本文写成“已经自动执行”。
+
+门禁落地状态（2026-07-27）：`cargo xtask arch-check` 已实现本节第 1/2（跨库直连）、3/4/11（依赖方向与 owner-agnostic 反向依赖）、10（文件行数）、17（legacy signed read-only 存续）项的静态检查与 ratchet，基线冻结在 [migrations/baseline-2026-07/legacy-allowlist.toml](migrations/baseline-2026-07/legacy-allowlist.toml)。其余需 AST/语义分析或运行时证据的项（5–9、12–16、18–27）仍为 TODO，覆盖清单见 [baseline-2026-07/README.md](migrations/baseline-2026-07/README.md)，未实现的项不得声称已自动执行。
 
 ## 14. 例外流程
 

--- a/docs/architecture/migration-plan.md
+++ b/docs/architecture/migration-plan.md
@@ -1,10 +1,12 @@
 # Rust Quant 架构迁移计划
 
-- 状态：计划中
+- 状态：计划中（阶段 0 基线已冻结、阶段 1 防腐 ratchet 已落地，业务搬迁未开始）
 - 首次制定：2026-07-18
-- 最近修订：2026-07-21
+- 最近修订：2026-07-27
 - 目标架构：[Rust Quant 长期目标架构](target-architecture.md)
 - 数据访问规则：[业务代码与数据访问放置规范](business-code-and-data-access.md)
+- AI 执行协议：[AI 架构迁移执行协议](ai-migration-execution-protocol.md)
+- 阶段 0/1 产物：[baseline-2026-07](migrations/baseline-2026-07/README.md)（依赖图、Owner Ledger、运行拓扑、legacy allowlist、`cargo xtask arch-check`）
 
 ## 1. 目的
 
@@ -42,7 +44,7 @@
 | 删除门 | 调用方、配置、表、监控和白名单的删除条件 |
 | 验证 | unit、integration、contract、parity、recovery、deploy contract |
 
-没有填写完整清单，不开始迁移。
+该清单必须保存为 `docs/architecture/migrations/<migration-id>-<slug>/manifest.toml`，使用 [`migrations/_template.toml`](migrations/_template.toml) 的机器可读 schema；聊天计划不能替代 Manifest。每个切片只能选择 `structure_only`、`behavior_change`、`cutover`、`legacy_delete` 中一个主模式，并固定已提交的 `architecture_baseline_git_sha`。没有填写完整清单、基线未冻结或模式混合时，不开始迁移。
 
 ## 4. 阶段 0：冻结当前基线与 Owner Ledger
 
@@ -51,8 +53,11 @@
 - 为 Strategy Signal、Web Execution Task、Readiness、订单结果和 internal API 建立 Contract snapshot；
 - 记录 `quant_core` 与 `quant_web` 当前表 owner、写入者、读取者和数据量；
 - 为关键策略建立固定输入下的 evaluator、portfolio、risk 和 execution parity 基线；
-- 为 Vegas 固定 DatasetManifest、Strategy Runtime Snapshot、SimulationProfile、指标预热长度、风险/资金配置、费用、滑点与随机 Seed；
+- 为 Vegas 固定 DatasetManifest、四个 Domain Policy Snapshot、ExecutionDecisionContext、SimulationProfile、指标预热长度、动态 Evidence、费用、滑点与随机 Seed；
 - 记录 Vegas 当前 backtest、paper/live 的实际窗口差异、状态缓存 identity 和信号字段差异；
+- 记录 `TradingState`、`deal_signal`、`StrategyExecutor`、全局 Registry、零字段 Service/Calculator 的调用方、owner 混合和删除条件；
+- 记录 `BasicRiskConfig`、`BasicRiskStrategyConfig` 及 live/helper 止盈止损计算的字段来源、默认值、舍入与触发顺序；
+- 记录当前 Cargo 传递依赖、总 CLI binary 清单、Docker 实际复制内容和 CI build matrix，区分 Research-only、共享 Domain 和生产 App 变更；
 - 记录订单状态、lease、重试、保护单和恢复的现有行为。
 
 验证：同一基线可以在迁移前后重复执行，并能识别策略结论、订单参数、状态机和 Contract 漂移。
@@ -62,7 +67,14 @@
 - 建立 `apps` 与 `crates/{domains,quant,contracts,adapters,platform}` 目录约定；
 - 建立最小 command/query/event-consumer 三个模板；
 - 建立 `cargo xtask arch-check` 的只读报告；
+- 建立 Migration Manifest 模板、人工 Evidence 和 `cargo xtask migration-check --manifest <path>` 的 schema/基线/diff-scope 只读报告；
+- 建立 `release-units/{core-runtime,core-maintenance,quant-lab}.toml`，先记录 root package、binary allowlist、forbidden package、生产部署资格和测试集；
+- 将六个生产组合根拆为独立 Cargo package，但先继续打入同一个 `core-runtime` 镜像；schema-tool 与 quant-lab 分别使用独立工件；
 - 保存 legacy allowlist，CI 先禁止新增违规；
+- 对新增零字段 Service/Manager/Calculator、Aggregate 公开可变不变量、Model/Policy 隐式时间/环境变量/全局业务缓存建立 ratchet；
+- 建立由 Git diff、Cargo 反向传递依赖和 Release Unit Manifest 推导的 build-impact 报告：Research-only 改动不构建或部署 `core-runtime`，共享 Domain 改动不得漏掉生产构建和 parity，无法判断时 fail closed；
+- 增加生产镜像内容检查：实际 binary 与 `core-runtime` allowlist 完全一致，禁止 Research/Backtest/Paper/candidate/schema-tool；
+- 只有 build-impact 基线证明候选策略与已发布策略确有独立编译/发布生命周期时，才在 Strategy owner 内建立 api/released/candidates 三个 catalog 级 package；`signal-worker` 不依赖 candidates，`quant-lab` 可以依赖 released + candidates；
 - 建立一个 Postgres Adapter crate 的 owner module 骨架；
 - 建立 Research Domain 最小骨架，只含 Experiment/Run/Evidence identity、Port 与状态机，不先搬回测交易逻辑；
 - Migration 采用单一有序目录和 owner 文件名。
@@ -145,6 +157,11 @@ Research::BacktestRun + DatasetManifest
 - 引入 `StrategyEvaluationStateKey = EvaluationScopeId + RuntimeSnapshotId + MarketStreamPartition`，消除并行 Run 和仅按 symbol/period/type 缓存的歧义；
 - Strategy evaluator 不再接收账户级 `BasicRiskStrategyConfig`；
 - 将历史 `position_leverage` 的资金比例语义迁为 Portfolio `allocation_ratio`，真实交易所 leverage 单独建模；
+- 拆分并冻结 `StrategyRuntimeSnapshot`、`PortfolioPolicySnapshot`、`RiskPolicySnapshot`、`ExecutionPlanningPolicySnapshot`；Strategy 快照不再承载用户风险或其他 owner 政策，同一 payload 不再解析为两个语义重叠的 Risk 类型；
+- 引入 `ExecutionDecisionContextSnapshot`，由 Execution 在请求 intake 事务中绑定四个 Published Policy Snapshot，并让 RiskDecision、OrderIntent、Plan、Attempt 与恢复证据引用同一 Context；
+- 引入 `ResearchRunSpec`，固定 DatasetManifest、四个 Policy Snapshot、SimulationProfile、模拟账户初态和 Clock/Seed；动态 Market/Account/Instrument Evidence 与配置分离；
+- Strategy 保留候选失效价、退出意图/候选止盈政策，Risk 使用唯一 Policy 产生不可放宽的最终止损、风险边界和批准数量，Execution 合并 Strategy exit intent 与 RiskDecision 生成 `OrderPlan`/`ProtectionPlan`；
+- `trade_fee_rate`、slippage、funding、latency 和 candle path 全部迁入 `SimulationProfile`，不再混入风险配置；
 - `quant/backtest` 只迁移确定性时钟、事件调度、撮合、费用、滑点和资金费；Research use case 驱动同一 Strategy、Portfolio、Risk 和 OrderPlan API；
 - 多币种在同一 decision time 先收集全部 Signal，再统一排序、净额和分配；新增 symbol 重排不变性测试；
 - 固定指标预热/最大历史窗口，解释并消除当前 backtest 与 live 的 7000/4000 等不一致；
@@ -152,6 +169,7 @@ Research::BacktestRun + DatasetManifest
 - ResearchEvidence 由 Research owner 发布：先内容寻址上传大对象，再以单一数据库事务发布 Completed EvidenceManifest；
 - 明确 `ResearchBar` 不覆盖 lease/outbox/Unknown/recovery；PaperEvent 与 RecoveryHarness 分别建立独立验收；
 - 建立现有 pipeline 与新 pipeline 的逐事件 parity 报告，并对所有差异分类。
+- parity 报告记录实际调用的业务 symbol 与各快照 identity/version/hash，并比较 EvaluationState before/after、Signal、Target、RiskDecision、OrderPlan、ProtectionPlan 和 decision trace；最终 PnL 接近不能通过。
 
 完整逐文件分配和切换门见 [Vegas 与现有回测主链迁移实战](vegas-backtest-migration.md)。
 
@@ -199,6 +217,15 @@ Research::BacktestRun + DatasetManifest
 10. Research Domain、其他策略的 Backtest/live parity、Analytics 与 ResearchEvidence；Vegas 已作为第二验收切片先固定模板。
 
 每个步骤继续使用第 3 节清单，不能在同一切片中同时调整策略判断、资本分配、风险阈值和执行协议。
+
+代码形态迁移同样按垂直切片完成：
+
+- `TradingState` 拆为 Strategy EvaluationState、Research SimulationLedger 和 owner typed output，禁止重建新的万能 Context；
+- `deal_signal` 由 Research use case 的跨域编排逐步绞杀，不能整体搬入 `impl` 或新 `TradingEngineService`；
+- 无状态计算优先迁为纯函数；共享冻结配置的决策迁为 Policy；
+- 有 identity/生命周期的 Order、Run、Release 使用 Aggregate，关键字段通过 transition 保护；
+- Worker 只保留循环、Contract 映射、Use Case 调用和 ack/checkpoint；
+- Trait 只保留真实 Port、稳定 API 或多实现边界，删除没有调用证据的工厂/基类式抽象。
 
 ## 9. 阶段 5：运行入口收敛
 
@@ -249,11 +276,14 @@ Research::BacktestRun + DatasetManifest
 - 把 Experiment、DatasetManifest、样本、成本、SimulationProfile 和评估写入 ResearchEvidence；
 - 把 lifecycle、promote、rollback 写入 `StrategyRelease`；
 - 发布不可变 `StrategyRuntimeSnapshot` 给数据面；
+- Portfolio、Risk、Execution 分别发布自己的不可变 Policy Snapshot；
+- Web `risk_profile_ref + version` 经 Core Risk 校验、默认值展开和 canonical hash 后幂等解析为 `RiskPolicySnapshot`，缺失或不兼容时不允许默认放行；
+- Execution 发布不可变 `ExecutionDecisionContextSnapshot`；Research 发布不可变 `ResearchRunSpec`；
 - 为有状态 evaluator 建立由 EvaluationScopeId、RuntimeSnapshotId 与 MarketStreamPartition 组成的状态身份；
 - Registry、Catalog、Signal builder 和 Worker 使用同一 strategy identity；
 - legacy alias 只在边界 Adapter 保留。
 
-验证：历史 Definition/Artifact/Evidence 字节身份不被覆盖；相同 RunId、Manifest、Seed 可重放；Release 变化不会修改历史信号和回测事实。
+验证：历史 Definition/Artifact/Evidence 字节身份不被覆盖；相同 RunSpec、Context、动态 Evidence 和 EvaluationState before 可逐层重放；Release 变化不会修改历史信号、订单或回测事实。
 
 ## 11. 阶段 7：控制面与数据面解耦
 
@@ -294,6 +324,11 @@ Research::BacktestRun + DatasetManifest
 - 架构门禁从 ratchet 收敛为全量规则，legacy allowlist 清零；
 - Strategy 不直接生成最终订单，Portfolio/Account/Risk/Execution 边界可验证；
 - Strategy evaluator 不读取环境变量、不接收账户风险配置，回测/live 使用同一评估状态迁移；
+- backtest、paper、shadow、canary、live 使用同一 Strategy entry/exit、Portfolio、Risk/final-stop 和 Execution planning 实现；exact parity 同时证明四个 Policy Snapshot、Decision Context、动态 Evidence、EvaluationState before 和 Clock identity 一致；
+- Research-only crate 不进入生产 App 依赖图和 `core-runtime` 镜像；Research-only 变更无生产部署资格，共享 Domain 变更由 Cargo 依赖图触发受影响生产构建与 parity；
+- 三个 Release Unit Manifest、实际镜像内容、Compose 角色和 deploy contract 一致；
+- 尚未发布的候选策略只存在于 Strategy candidates catalog；晋级 released catalog 后才进入生产构建与 live RuntimeSnapshot，不为每个策略建立服务或 crate；
+- 新增代码按 Entity/Value Object、纯函数、Policy、Use Case、Port、Adapter 唯一归类，不再新增零状态万能 Service/Calculator；
 - Web ExecutionRequest 与 Core OMS 事实完全分离；
 - 数据库 CRUD、事务、Outbox 和查询归属可以唯一定位；
 - 成交反馈、持续风险、保护和 Reconciliation 闭环完整；
@@ -301,3 +336,4 @@ Research::BacktestRun + DatasetManifest
 - 所有外部 mutation 都有幂等、Unknown、恢复和对账证据；
 - legacy 入口、兼容字段和旧表写入全部有明确结束结论。
 - 现有 Vegas 回测入口完成 parity 切换后，`BacktestRunner`、`BacktestExecutor`、万能 `BacktestContext` 与 `deal_signal` 的对应 legacy 职责均有删除证据。
+- 每个架构迁移切片都有版本化 Manifest、当前 revision 的 Evidence 和 Migration Verdict；规范基线、实际 diff、迁移模式、授权与完成状态一致。

--- a/docs/architecture/migrations/baseline-2026-07/README.md
+++ b/docs/architecture/migrations/baseline-2026-07/README.md
@@ -1,0 +1,61 @@
+# 阶段 0/1 迁移前准备产物(baseline-2026-07)
+
+- 冻结日期:2026-07-27
+- `architecture_baseline_git_sha`:`660407f438db52acde8318e705b26ad05948aa0a`
+- 上位:[迁移计划 阶段 0/1](../../migration-plan.md)、[依赖规则 §13](../../dependency-rules.md)
+
+本目录是迁移正式开始前的准备产物:冻结当前基线 + 落地防腐 ratchet 闸门。**不搬任何业务、不建目标目录空壳。**
+
+## 产物清单
+
+| 文件 | 内容 |
+|---|---|
+| [dependency-graph.md](dependency-graph.md) | 阶段 0:14 crate 依赖图、规模、已知违规基线 V1–V5 |
+| [owner-ledger.md](owner-ledger.md) | 阶段 0:现有 crate/module → 目标 owner 映射矩阵 + services 拆分线 |
+| [runtime-topology.md](runtime-topology.md) | 阶段 0:七个 quant_core_* 角色 bin → app → 装配冻结 |
+| [legacy-allowlist.toml](legacy-allowlist.toml) | 阶段 1:ratchet 输入基线(V1–V5 + 删除条件 + 复查日期) |
+
+## 防腐闸门 `cargo xtask arch-check`
+
+只读架构检查器(`xtask/` crate,不进生产依赖图)。用法:
+
+```bash
+cargo xtask arch-check          # 人读摘要
+cargo xtask arch-check --json   # 机器可读
+# 等价(无需 alias):
+cargo run -p xtask -- arch-check
+```
+
+`cargo xtask` 别名定义在 `.cargo/config.toml`（该路径被 `.gitignore` 忽略，不随仓库分发）。clone 后如需该别名，自行在 `.cargo/config.toml` 加：
+
+```toml
+[alias]
+xtask = "run --quiet --package xtask --"
+```
+
+或直接用上面的 `cargo run -p xtask -- arch-check`，无需别名。
+
+ratchet 语义:读 `legacy-allowlist.toml` 冻结基线,运行违规数 **> 基线即 FAIL**,`≤` 通过。当前 HEAD 跑通即 PASS(违规数 == 基线,自洽)。
+
+### dependency-rules.md §13 覆盖状态
+
+| §13 项 | 规则 | 状态 |
+|---|---|---|
+| 1/2 | 跨库直连 quant_web/quant_news 禁令 | ✅ 已实现(生产源码连接串扫描,排除测试 fixture;运行时门禁在 sqlx_pool.rs) |
+| 3/4(方向) | 依赖方向 / owner-agnostic 反向依赖 | ✅ 已实现(cargo metadata 分层 + V2 显式判定) |
+| 10 | 文件行数闸门(1000 WARN / 2000 硬失败) | ✅ 已实现(复用 check_code_file_line_limit.sh 阈值) |
+| 11 | quant/* 依赖业务 Domain | ✅ 由方向检查覆盖(V1 analytics→strategies) |
+| 17 | legacy signed read-only 账户直读 | ✅ 存续核对(V3/V4/V5 文件存在性) |
+| 8 | Contract 未声明变化 | ⏳ TODO(需 Contract snapshot 基线,属阶段 2) |
+| 13 | evaluator 读账户配置/生成订单数量 | ⏳ TODO(需 AST/语义分析) |
+| 18 | 零字段 Service/Manager/Calculator | ⏳ TODO(需 AST) |
+| 19 | Aggregate 可变不变量 / Model 读系统时间 | ⏳ TODO(需 AST) |
+| 20 | backtest/live 重复实现 | ⏳ TODO(需语义分析) |
+| 23/24 | 镜像 binary allowlist / package 依赖闭包 | ⏳ TODO(需 release-units + 镜像检查) |
+| 其余 | 5/6/7/9/12/14/15/16/21/22/25/26/27 | ⏳ TODO(需运行时证据或语义分析,留待后续) |
+
+TODO 项不在本次实现,也**不假装已覆盖**(遵守 dependency-rules.md:405)。随迁移推进按需补齐检查器。
+
+## CI 接入
+
+在 CI pipeline 加一步 `cargo xtask arch-check` 即可(退出码非零阻断)。本仓 CI 配置若不在可改范围,则本工具支持本地/pre-commit 运行,不谎称已接 CI。

--- a/docs/architecture/migrations/baseline-2026-07/dependency-graph.md
+++ b/docs/architecture/migrations/baseline-2026-07/dependency-graph.md
@@ -1,0 +1,91 @@
+# 阶段 0 基线:Workspace 依赖图与违规基线
+
+- 状态:已冻结
+- 冻结日期:2026-07-27
+- `architecture_baseline_git_sha`:`660407f438db52acde8318e705b26ad05948aa0a`
+- 上位:[迁移计划 阶段 0](../../migration-plan.md)、[依赖规则 §3/§13](../../dependency-rules.md)
+
+本文件冻结迁移开始前的 workspace 内 crate 依赖现状与已知违规基线。它是 [`../baseline-2026-07/legacy-allowlist.toml`](legacy-allowlist.toml) 的推导依据,也是 `cargo xtask arch-check` ratchet 的语义参照。
+
+## 1. Workspace 成员(冻结时 14 crate)
+
+清理悬空 `rust-quant-ai-analysis` path 依赖后,根 `Cargo.toml` members 与 `crates/` 目录一致,共 14 个:
+
+```
+common, core, domain, infrastructure, services, trading,
+market, indicators, strategies, risk, execution,
+orchestration, analytics, rust-quant-cli
+```
+
+外部 path 依赖(不属迁移范围):`crypto_exc_all = { path = "../crypto_exc_all" }`;`[patch.crates-io] okx = { path = "../crypto_exc_all/okx_rs" }`。
+
+## 2. 依赖方向(仅 workspace 内 path 依赖)
+
+```text
+common      -> (无)
+domain      -> (无)
+core        -> common
+trading     -> domain
+analytics   -> common, core, strategies          # ⚠ 违规:owner-agnostic 反向依赖业务层
+market      -> common, core, domain
+indicators  -> common, core, domain, market
+strategies  -> common, core, domain, indicators, trading
+risk        -> common, core, domain, market
+execution   -> common, core, market, risk, strategies, indicators   # ⚠ 异常:依赖 strategies/indicators 却不依赖 domain
+infrastructure -> common, core, domain
+services    -> common, core, domain, infrastructure, market, indicators,
+               strategies, trading, risk, execution, analytics
+orchestration -> common, core, domain, infrastructure, services, market,
+               strategies, indicators, risk, execution
+cli         -> (全部 13 个)
+```
+
+## 3. 依赖分层(叶 -> 根,建议迁移顺序参考)
+
+1. 零内部依赖:`common`、`domain`
+2. 一层:`core`、`trading`
+3. 二层:`market`、`infrastructure`
+4. 三层:`indicators`、`risk`、`analytics`
+5. 四层:`strategies`
+6. 五层:`execution`
+7. 聚合层:`services`
+8. 编排层:`orchestration`
+9. 入口:`rust-quant-cli`
+
+## 4. 规模基线
+
+| crate | 文件数 | 总行数 | >1000 行文件(非测试) |
+|---|---|---|---|
+| common | 13 | 653 | — |
+| core | 13 | 1088 | — |
+| domain | 38 | 4700 | — |
+| infrastructure | 28 | 6528 | — |
+| services | 102 | 44729 | market_velocity_signal 1984;execution_take_profit 1502;execution_audit 1435;execution_protection 1121 |
+| trading | 5 | 216 | — |
+| market | 23 | 4214 | — |
+| indicators | 62 | 19999 | vegas/config 1367;liquidity_sweep_reversal 1273;trade_signal 1137 |
+| strategies | 110 | 21554 | framework/backtest/position 1099;keltner_channel_scalper/strategy 1006 |
+| risk | 24 | 2297 | — |
+| execution | 5 | 1133 | — |
+| orchestration | 48 | 8489 | infra/strategy_config 1146 |
+| analytics | 17 | 3954 | — |
+| rust-quant-cli | 246 | 107945 | 20+(最大 market_velocity_event_backtest ~1998) |
+
+全仓约 734 个 .rs 文件 / 22.8 万行。cli 约 47%、services 约 20%。
+
+## 5. 已知违规基线(冻结时)
+
+| # | 违规 | 位置 | 目标规则 | 迁移归属 |
+|---|---|---|---|---|
+| V1 | owner-agnostic 层反向依赖业务层 | `analytics -> strategies` | dependency-rules §13-11 | analytics 迁 `quant/analytics` 时打断 |
+| V2 | 依赖 strategies/indicators 却不依赖 domain,耦合方向偏重 | `execution` crate | dependency-rules §3/§4 | execution 迁 `domains/execution` 时纠正 |
+| V3 | legacy signed read-only 账户直读 | `crates/risk/src/legacy_signed_read_only.rs` | dependency-rules §13-17 精神 | 收敛到 reconciliation + quant-web adapter |
+| V4 | 同上 | `crates/execution/src/order_manager/order_service.rs`、`swap_order_service.rs` | 同上 | 同上 |
+| V5 | 同上 | `crates/infrastructure/src/exchanges/okx_adapter.rs` | 同上 | 同上 |
+
+跨库直连:**已治理,基线为 0**。quant_web 走 HTTP(`crates/services/src/rust_quan_web/execution_task_client.rs`);quant_core DB 单例有 URL 门禁(`crates/core/src/database/sqlx_pool.rs`,拒绝指向 quant_web);无 quant_news 直连。
+
+## 6. 冻结口径
+
+- 本图基于 `cargo metadata` 与逐 crate `Cargo.toml` path 依赖静态盘点,不含外部 crates.io 传递依赖。
+- V1–V5 是 ratchet 允许存在的 legacy 基线,登记在 `legacy-allowlist.toml`;迁移期只允许违规数下降,禁止新增。

--- a/docs/architecture/migrations/baseline-2026-07/legacy-allowlist.toml
+++ b/docs/architecture/migrations/baseline-2026-07/legacy-allowlist.toml
@@ -1,0 +1,66 @@
+# 阶段 0 Legacy 违规基线 allowlist。
+# 由 cargo xtask arch-check 读取:运行违规数 > 本文件登记的基线即 FAIL,<= 通过。
+# 迁移期只允许违规数下降,禁止新增。删除条件满足后从本文件移除对应条目。
+#
+# 上位:docs/architecture/migration-plan.md 阶段 0/1、dependency-rules.md §13(ratchet 约定)。
+
+schema_version = 1
+architecture_baseline_git_sha = "660407f438db52acde8318e705b26ad05948aa0a"
+frozen_at = "2026-07-27"
+
+# 跨库直连基线:0(已治理,不得新增)
+[cross_db_direct]
+baseline_count = 0
+note = "quant_web 走 HTTP(execution_task_client.rs);quant_core DB 单例 URL 门禁(sqlx_pool.rs);无 quant_news 直连。"
+
+# 依赖方向违规(owner-agnostic 反向依赖 / 层次异常)
+[[dependency_violation]]
+id = "V1"
+edge = "analytics -> strategies"
+rule = "dependency-rules §13-11(quant/* 禁止依赖业务 Domain)"
+owner = "analytics -> quant/analytics(迁移后)"
+deletion_condition = "analytics 迁入 quant/analytics 且对 strategies 的依赖被打断(改依赖 quant 基础与 contracts)"
+review_by = "2026-10-01"
+
+[[dependency_violation]]
+id = "V2"
+edge = "execution -> {strategies, indicators}(且不依赖 domain)"
+rule = "dependency-rules §3/§4(依赖方向与 Domain 顺序)"
+owner = "execution -> domains/execution(迁移后)"
+deletion_condition = "execution 迁入 domains/execution,依赖收敛为本 Domain model + 上游 api,不再反向依赖 strategies/indicators"
+review_by = "2026-10-01"
+
+# legacy signed read-only 账户直读路径(env 门禁 LEGACY_SIGNED_READ_ONLY_CONFIRM)
+[[legacy_path]]
+id = "V3"
+path = "crates/risk/src/legacy_signed_read_only.rs"
+kind = "signed_read_only_account_read"
+rule = "dependency-rules §13-17 精神(账户读取应经 reconciliation + quant-web adapter)"
+owner = "risk -> domains/reconciliation + adapters/quant-web-client(迁移后)"
+deletion_condition = "所有调用方改走 quant_web execution reconciliation 路径,env 门禁与本模块删除"
+review_by = "2026-10-01"
+
+[[legacy_path]]
+id = "V4"
+path = "crates/execution/src/order_manager/order_service.rs"
+path_also = "crates/execution/src/order_manager/swap_order_service.rs"
+kind = "signed_read_only_account_read"
+rule = "dependency-rules §13-17 精神"
+owner = "execution -> domains/reconciliation + adapters/quant-web-client(迁移后)"
+deletion_condition = "同 V3"
+review_by = "2026-10-01"
+
+[[legacy_path]]
+id = "V5"
+path = "crates/infrastructure/src/exchanges/okx_adapter.rs"
+kind = "signed_read_only_account_read"
+rule = "dependency-rules §13-17 精神"
+owner = "infrastructure -> adapters/exchange-gateway(迁移后)"
+deletion_condition = "同 V3"
+review_by = "2026-10-01"
+
+# 汇总:arch-check 用的聚合基线计数
+[baseline_counts]
+dependency_violations = 2   # V1, V2
+legacy_paths = 3            # V3, V4, V5
+cross_db_direct = 0

--- a/docs/architecture/migrations/baseline-2026-07/owner-ledger.md
+++ b/docs/architecture/migrations/baseline-2026-07/owner-ledger.md
@@ -1,0 +1,66 @@
+# 阶段 0 Owner Ledger:现有 crate -> 目标 owner 映射矩阵
+
+- 状态:已冻结
+- 冻结日期:2026-07-27
+- `architecture_baseline_git_sha`:`660407f438db52acde8318e705b26ad05948aa0a`
+- 上位:[目标架构 §4.2/§5](../../target-architecture.md)、[依赖规则 §2](../../dependency-rules.md)、[迁移计划 阶段 0/4](../../migration-plan.md)
+
+本文件把当前 14 个扁平 crate 的顶层 module 映射到目标架构的 owner 分区(`domains/quant/adapters/contracts/platform/apps`)。它是阶段 4"按业务链路迁移"的落点参照,不是施工顺序表(顺序见 migration-plan.md 阶段 2-4)。
+
+## 1. crate 级落点概览
+
+| 现有 crate | 主要落点 | 说明 |
+|---|---|---|
+| `common` | `platform/kernel` + `quant/math`(部分) | 常量/错误/共享类型/时间工具;按 owner 无关性拆分 |
+| `core` | `adapters`(db/cache)+ `platform`(config/logger) | `database/sqlx_pool.rs` 全局 PgPool -> adapters/postgres 基础 |
+| `domain` | `domains/*` 各 owner 的 model + ports | 零依赖纯实体/trait,是各 owner model 与 port 的现成种子 |
+| `infrastructure` | `adapters/postgres` + `adapters/exchange-gateway` | repositories -> postgres owner module;exchanges -> exchange-gateway |
+| `services` | **拆分**(见 §2) | 最需按 owner 拆分的高价值目标 |
+| `trading` | `domains/portfolio` + `domains/execution` 薄层 | audit/order/portfolio |
+| `market` | `domains/market` + `adapters`(行情流) | 内部按 reference/ 与 stream/ 分 module(目标 §4.2) |
+| `indicators` | `quant/indicators`(纯指标) + `domains/strategy`(vegas/strategy 部分) | 指标与策略当前耦合,需拆 |
+| `strategies` | `domains/strategy` + `quant/backtest`(framework/backtest 部分) | 文件数最多;backtest 归 quant |
+| `risk` | `domains/risk` + `quant/backtest`(backtest 部分) | legacy_signed_read_only 收敛(见 legacy-allowlist V3) |
+| `execution` | `domains/execution` | 纠正依赖方向(legacy-allowlist V2) |
+| `orchestration` | `domains/control` + `apps`(调度/工作流) | jobs/scheduler/workflow -> app 组合根;control 事实 -> domains/control |
+| `analytics` | `quant/analytics` | 打断 analytics->strategies 反向依赖(legacy-allowlist V1) |
+| `rust-quant-cli` | `apps/*` + `domains/research` + `quant/*` | 角色 bin -> apps;research/backtest 工具 -> research + quant |
+
+## 2. services 拆分线(最高价值目标)
+
+`crates/services` 的 `rust_quan_web` 子模块(约 45 文件)是 execution/account/reconciliation 三 owner 的当前合体,靠 `ExecutionWorkerLane` 枚举分流(见 [runtime-topology.md](runtime-topology.md))。目标拆分:
+
+| services 顶层 module | 目标 owner |
+|---|---|
+| `exchange` | `adapters/exchange-gateway` |
+| `market` | `domains/market`(velocity signal)+ `adapters` |
+| `notification` | `adapters/notification` |
+| `risk` | `domains/risk` |
+| `strategy` | `domains/strategy` |
+| `trading` | `domains/portfolio` / `domains/execution` |
+| `rust_quan_web`(Execution lane) | `domains/execution` |
+| `rust_quan_web`(Confirmation lane) | `domains/account` |
+| `rust_quan_web`(ReportReplay lane) | `domains/reconciliation` |
+| `rust_quan_web::execution_task_client` | `adapters/quant-web-client`(已 HTTP 化,直接归位) |
+| `rust_quan_web::market_velocity_live_readiness` | `domains/control`(readiness 快照)/ `domains/account`(session readiness) |
+
+## 3. owner 覆盖核对(目标 9 个 domain owner)
+
+| 目标 owner | 现有来源 |
+|---|---|
+| control | orchestration(scheduler/config/readiness)、services::market_velocity_live_readiness |
+| market | market crate、services::market、indicators 数据侧 |
+| strategy | strategies crate、indicators::trend::vegas::strategy、services::strategy |
+| portfolio | trading::portfolio |
+| account | services::rust_quan_web(Confirmation lane)、risk::account |
+| risk | risk crate、services::risk |
+| execution | execution crate、services::rust_quan_web(Execution lane)、trading::order |
+| reconciliation | services::rust_quan_web(ReportReplay lane)、三处 legacy_signed_read_only 收敛后 |
+| research | rust-quant-cli 的 research/backtest 工具、strategies::framework::backtest |
+
+owner-agnostic `quant/`:math(common 部分)、indicators(纯指标)、backtest(strategies::framework::backtest + risk::backtest)、analytics(analytics crate)。
+
+## 4. 冻结口径
+
+- 本映射是目标落点,不代表已迁移;实际搬块须走 migration-plan.md 阶段 2 Golden Slice 模板 + 每切片 Manifest。
+- "第一期只建用得着的 crate,别建空壳"——本 ledger 不触发提前创建目标目录。

--- a/docs/architecture/migrations/baseline-2026-07/runtime-topology.md
+++ b/docs/architecture/migrations/baseline-2026-07/runtime-topology.md
@@ -1,0 +1,54 @@
+# 阶段 0 基线:生产运行拓扑冻结
+
+- 状态:已冻结
+- 冻结日期:2026-07-27
+- `architecture_baseline_git_sha`:`660407f438db52acde8318e705b26ad05948aa0a`
+- 上位:[生产运行与恢复](../../production-runtime.md)、[目标架构 §3.2/§4.2](../../target-architecture.md)、[迁移计划 阶段 0](../../migration-plan.md)
+
+冻结迁移开始前的 Core 生产角色装配现状。`quant-core-worker` 是多入口运行时,靠不同 bin/command 切角色,共享同一份二进制。
+
+## 1. 角色 bin -> app 入口 -> 装配
+
+主二进制:`[[bin]] rust_quant -> src/main.rs`;`src/lib.rs` 只 `pub mod app;`。角色 worker 是 `src/bin/quant_core_*.rs` 薄 wrapper(先 `rust_quant_cli::app_init().await?` 再调 app/services 逻辑)。
+
+| 角色 bin(`crates/rust-quant-cli/src/bin/`) | app 入口 | 装配 |
+|---|---|---|
+| `quant_core_control_api.rs` | `app::control_api::run_control_api()` | 控制面 API(orchestration/services) |
+| `quant_core_market_worker.rs` | `app::market_worker::run_market_worker()` | 行情采集(market/services) |
+| `quant_core_signal_worker.rs` | `app::signal_worker::run_signal_worker()` | 信号生成(indicators/strategies/services) |
+| `quant_core_execution_worker.rs` | `app::execution_worker_runtime::run_execution_worker_lane(ExecutionWorkerLane::Execution)` | 下单执行 lane |
+| `quant_core_account_worker.rs` | 同上,`ExecutionWorkerLane::Confirmation` | 账户/成交确认 lane |
+| `quant_core_reconciliation_worker.rs` | 同上,`ExecutionWorkerLane::ReportReplay` | 对账/报告回放 lane |
+| `quant_core_schema_ensure.rs` | 独立 53 行 main | DB schema 确保(core/infrastructure) |
+
+## 2. 关键事实:三 lane 共用运行时
+
+`execution / account / reconciliation` 三个角色**共用同一运行时** `app::execution_worker_runtime::run_execution_worker_lane`,靠 `ExecutionWorkerLane` 枚举(`Execution` / `Confirmation` / `ReportReplay`)分流。逻辑主体在 `crates/services/src/rust_quan_web/execution_worker.rs` 及其 `*_section.rs` 分片。
+
+这是目标架构中 `domains/execution`(Execution lane)、`domains/account`(Confirmation lane)、`domains/reconciliation`(ReportReplay lane)三个 owner 的拆分线——现状是三者在一个 lane runtime 里合体。见 [owner-ledger.md §2](owner-ledger.md)。
+
+## 3. app/ 角色与子命令(冻结时)
+
+`app/mod.rs` 声明 28 个模块。运行时角色:`control_api`、`market_worker`、`signal_worker`、`execution_worker_runtime`、`internal_server`(1146 行内部 HTTP)、`bootstrap*`。
+
+market_velocity 家族(最大体量):`market_velocity_backfill`(1514)、`market_velocity_event_backtest`(1998)、`market_velocity_kline_scanner`、`market_velocity_live_handoff`(1964)、`market_velocity_strategy_config`。
+
+research/panel 家族:market_beta_*、market_cross_*、market_*_reversal_research、market_structure_choch_fvg_research 等 -> 目标 `domains/research` + `quant/*` + `apps`。
+
+## 4. 与目标 apps 的对应
+
+| 目标 app(target §4.2) | 现状来源 |
+|---|---|
+| control-api | quant_core_control_api |
+| market-worker | quant_core_market_worker |
+| signal-worker | quant_core_signal_worker(含雷达 handoff 消费 + 订阅扇出,尚未接入) |
+| account-worker | quant_core_account_worker(Confirmation lane) |
+| execution-worker | quant_core_execution_worker(Execution lane) |
+| reconciliation-worker | quant_core_reconciliation_worker(ReportReplay lane) |
+| schema-tool | quant_core_schema_ensure |
+| quant-lab | src/bin/ 下 research/backtest 独立可执行 |
+
+## 5. 冻结口径
+
+- 新增或重命名 Core 角色必须同步生产 compose、deploy/rollback 脚本、deploy contract tests(CLAUDE.md 约束)。
+- 本拓扑是静态盘点;生产实际 command/profiles/env 开关以生产 compose 为准。

--- a/docs/architecture/target-architecture.md
+++ b/docs/architecture/target-architecture.md
@@ -2,7 +2,7 @@
 
 - 状态：已接受
 - 首次接受：2026-07-18
-- 最近修订：2026-07-21
+- 最近修订：2026-07-24
 - 适用范围：中低频、多策略、多账户、多交易所的生产量化平台
 - 代码放置细则：[业务代码与数据访问放置规范](business-code-and-data-access.md)
 - 生产运行规范：[生产运行与恢复](production-runtime.md)
@@ -57,6 +57,17 @@
 - 持续 Risk 初期可由 `account-worker` 装配；只有出现独立吞吐或隔离需求时才增加 `risk-worker`；
 - 每个策略默认是 Strategy 内的 module，不是独立 crate、Worker 或服务。
 
+业务边界、Rust crate、运行进程和 CI/CD Release Unit 是四个不同概念：
+
+- 先用 Domain module/crate 隔离业务 owner，不因新增策略或回测能力默认拆微服务；
+- `signal-worker`、`execution-worker` 等生产 App 不得依赖 `strategy-candidates`、`domains/research`、`quant/backtest`、`quant/analytics` 或 `quant-lab`；
+- Research 与生产 App 都依赖同一份 Strategy、Portfolio、Risk 和 Execution 公开业务实现，Research 不能反向提供“实盘依赖的业务包”；
+- 六个生产角色各自使用独立 App Cargo package，但继续打入同一个 `core-runtime` 镜像；`schema-tool` 属于 `core-maintenance`，Research/Backtest/Analytics/Paper 研究入口属于 `quant-lab`，不是生产镜像内容；
+- 只修改 `domains/research`、`quant/backtest`、`quant/analytics`、`strategy-candidates` 或 `apps/quant-lab` 时，目标 CI 只构建研究单元且不得触发生产部署；修改共享的 Strategy、Portfolio、Risk、Execution、Market、Contract 或生产 Adapter 时，必须按 Cargo 反向传递依赖触发受影响生产构建与 parity 回归；
+- 如果“新增尚未发布的候选策略”频繁导致生产 App 无意义重建，可在 Strategy owner 内按发布生命周期拆成 `strategy-api`、`strategy-released` 与 `strategy-candidates` 三个 workspace package：`quant-lab` 可以依赖 released + candidates，生产 `signal-worker` 只能依赖 api + released；这是编译/发布隔离，不是新增微服务；
+- 每个候选策略仍默认是 `strategy-candidates` 内的 module，不按策略建立服务或 crate。候选晋级 live 时必须进入 released catalog，冻结新的 Artifact/Release/RuntimeSnapshot，并重新通过生产构建与 parity；不能让 live App 在运行时依赖 Research 或直接加载候选目录；
+- 是否增加独立服务只由扩缩容、故障隔离、安全边界或独立发布生命周期决定，不能用服务拆分掩盖错误的 crate 依赖。
+
 ### 3.3 目标状态与实际状态分离
 
 - Strategy 产生预测和信号；
@@ -81,15 +92,164 @@
 
 外部 mutation 前，Risk owner 先按 `risk_evaluation_id` 持久化不可变审批；Execution 在固定完整 `OrderIntent`、`ExecutionPlan` 与 `ProtectionPlan` 后，以单一 owner 事务取得持久 `AccountOpeningSlot`，并原子提交首个持久状态 `SubmitPending`、幂等和 Outbox。事务提交后，Dispatcher 以 aggregate version/`send_claim`/fence 记录 attempt 并签发短期 `MutationPermit`；只有 Fenced Exchange Mutation Gateway 在网络 I/O 边界原子消费 current permit 后，才可在事务外调用 raw SDK。超时是 `Unknown`，不是失败；只有交易所能力可证明 `DefinitivelyAbsent`、不存在仍可发送的 permit，且 recovery transaction 新建提交 Outbox 时才沿原身份重试。系统不宣称跨 owner 数据库事务，也不宣称数据库与交易所之间的全局 exactly-once。完整顺序以 [ADR-0006](adr/0006-at-least-once-idempotency-and-recovery.md) 为唯一权威，事务实现边界见 [ADR-0007](adr/0007-owner-scoped-persistence-and-transaction-boundaries.md)。
 
-## 4. 目标物理目录
+### 3.8 Kill Switch 是分级作用域，不是单一开关
+
+生产实盘的熔断在真实运维中至少有五个作用域，粒度不同、owner 不同、优先级不同：
+
+- `global`：全平台停止新开仓，最高优先级，覆盖一切下级恢复；
+- `exchange`：某交易所故障或维护时停止该交易所的新 mutation；
+- `account`：单账户风控、欠费、凭证失效或用户主动停用；
+- `strategy`：某 `strategy_key@version` 行为异常时停止其下所有信号转执行；
+- `combo`：单个 `strategy × symbol` 订阅粒度停用。
+
+规则：
+
+- Kill Switch 状态是控制面拥有、**版本化、可被数据面本地读取的已发布快照**，不是同步管理 API；控制面不可用时，数据面必须能读到最近一次已发布的 kill 状态并据此 fail-closed，不得因读不到控制面而放行；
+- 生效判定取“任一命中作用域为停用即停用”，上级停用不可被下级恢复覆盖；`global`/`exchange` 停用期间，`account`/`strategy`/`combo` 的恢复不得放行新开仓；
+- 触发与解除都是显式 owner 命令并留审计：`global`/`exchange` 由运营控制面触发，`account`/`strategy`/`combo` 可由 Risk owner 的 RiskAction 触发；
+- Kill Switch 只阻断新增风险（开仓、加仓），不阻断 reduce-only 的保护、减仓和紧急平仓；后者仍走执行状态机与恢复协议。
+
+### 3.9 交易所配额是跨 App 的受管资源
+
+同一 `exchange × credential` 的 REST 权重、下单频率和 WS 订阅数是交易所侧的**共享全局预算**。market-worker 拉行情、execution-worker 下单/查单、reconciliation-worker 拉 open orders/positions/fills、account-worker 拉余额会同时消耗同一个桶：
+
+- 交易所配额是一等受管资源，owner 是 `exchange-gateway` Adapter，按 `exchange × credential` 维度记账与准入，不是各 App 进程内各自为政的 backpressure；
+- 热路径 mutation（下单、撤单、保护单）在配额紧张时优先于只读拉取（对账、行情补齐、余额刷新）；只读侧达到配额上限时降级或退避，绝不挤占 mutation 预算；
+- 配额准入失败属于可恢复门禁，使用持久 `next_eligible_at`/事件触发重新唤醒，不制造进程内热重试；
+- 单一 App 无法独占或耗尽共享凭证的全部配额而使其他角色饿死；分配策略与优先级由 gateway 显式声明，不隐藏在调用点。
+
+## 4. 目标架构总览与物理目录
+
+### 4.1 逻辑、运行与工件总览
+
+```mermaid
+flowchart TB
+    subgraph EXT["外部系统与跨仓库 Owner"]
+        direction LR
+        WEB["rust_quan_web / Admin<br/>用户、会员、订阅、风险配置、商业授权"]
+        NEWS["rust_quant_news<br/>新闻与情报事实"]
+        EXCHANGE["交易所"]
+    end
+
+    subgraph APPS["App 组合根与 Release Unit"]
+        direction LR
+        RUNTIME["core-runtime<br/>单一生产镜像<br/>control-api · market-worker · signal-worker<br/>account-worker · execution-worker · reconciliation-worker"]
+        MAINT["core-maintenance<br/>schema-tool / 有界维护 Job<br/>只允许显式运行"]
+        LAB["quant-lab<br/>Research · Backtest · Paper<br/>无生产部署资格"]
+    end
+
+    subgraph CORE["Rust Quant Core"]
+        direction TB
+
+        CONTROL["控制面<br/>Definition · Release · Policy Snapshot<br/>Readiness · 分级 Kill Switch(global/exchange/account/strategy/combo)"]
+
+        subgraph DATA["生产数据面 Domain"]
+            direction LR
+            MARKET["Market"] --> STRATEGY["Strategy"] --> PORTFOLIO["Portfolio"] --> RISK["Risk"] --> EXECUTION["Execution"] -->|"订单/成交公开事实"| RECON["Reconciliation"]
+            ACCOUNT["Account"] --> PORTFOLIO
+            ACCOUNT --> RISK
+            ACCOUNT --> EXECUTION
+            EXECUTION -. "FillEvent" .-> ACCOUNT
+            ACCOUNT --> RECON
+        end
+
+        RESEARCH["Research<br/>Experiment · Run · DatasetManifest<br/>SimulationProfile · ResearchEvidence"]
+
+        subgraph QUANT["Owner 无关的 Quant 纯机制"]
+            direction LR
+            QMI["math / indicators"]
+            QBA["backtest / analytics"]
+        end
+    end
+
+    subgraph BOUNDARY["Ports / Adapters / Contracts / Platform"]
+        direction LR
+        CONTRACTS["Versioned Wire Contracts<br/>只在进程/仓库边界映射"]
+        WEBCLIENT["quant-web-client<br/>只调用 Web Owner API"]
+        STORAGE["Owner-scoped Storage Adapters<br/>Postgres · Redis · Object Storage"]
+        GATEWAY["exchange-gateway + crypto_exc_all<br/>Fenced Mutation Gateway<br/>每 exchange×credential 配额记账与准入"]
+        PLATFORM["Platform<br/>Config · Lifecycle · Observability · Security"]
+    end
+
+    WEB <-->|"HTTP / Versioned Contract"| CONTRACTS
+    NEWS -->|"情报事实 Contract"| CONTRACTS
+    CONTRACTS <--> RUNTIME
+
+    RUNTIME --> CONTROL
+    RUNTIME --> MARKET
+    RUNTIME --> STRATEGY
+    RUNTIME --> ACCOUNT
+    RUNTIME --> PORTFOLIO
+    RUNTIME --> RISK
+    RUNTIME --> EXECUTION
+    RUNTIME --> RECON
+
+    CONTROL -->|"发布不可变快照"| STRATEGY
+    CONTROL -->|"发布不可变快照"| PORTFOLIO
+    CONTROL -->|"发布不可变快照"| RISK
+    CONTROL -->|"发布不可变快照"| EXECUTION
+
+    LAB --> RESEARCH
+    RESEARCH -. "只调用公开 Domain API" .-> MARKET
+    RESEARCH -.-> STRATEGY
+    RESEARCH -.-> PORTFOLIO
+    RESEARCH -.-> RISK
+    RESEARCH -.-> EXECUTION
+
+    STRATEGY --> QMI
+    RESEARCH --> QMI
+    RESEARCH --> QBA
+
+    RUNTIME -->|"需要时装配"| WEBCLIENT
+    WEBCLIENT -->|"Owner API"| WEB
+    RUNTIME -->|"通过 Owner Port / Adapter"| STORAGE
+    MAINT -->|"Schema / 有界维护"| STORAGE
+    LAB -->|"仅 Research / 历史数据"| STORAGE
+    RUNTIME -->|"仅 execution-worker：MutationPermit + 固定 payload"| GATEWAY
+    GATEWAY <-->|"Market / User Stream / Query / Mutation"| EXCHANGE
+    PLATFORM -. "装配与运行支撑" .-> RUNTIME
+    PLATFORM -.-> MAINT
+    PLATFORM -.-> LAB
+
+    classDef external fill:#f3f4f6,stroke:#64748b,color:#0f172a;
+    classDef runtime fill:#dcfce7,stroke:#15803d,color:#14532d;
+    classDef maintenance fill:#fef3c7,stroke:#b45309,color:#78350f;
+    classDef research fill:#f3e8ff,stroke:#7e22ce,color:#581c87;
+    classDef control fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a;
+    classDef domain fill:#ecfeff,stroke:#0e7490,color:#164e63;
+    classDef boundary fill:#fff7ed,stroke:#c2410c,color:#7c2d12;
+
+    class WEB,NEWS,EXCHANGE external;
+    class RUNTIME runtime;
+    class MAINT maintenance;
+    class LAB,RESEARCH,QBA research;
+    class CONTROL control;
+    class MARKET,STRATEGY,PORTFOLIO,RISK,EXECUTION,RECON,ACCOUNT,QMI domain;
+    class CONTRACTS,WEBCLIENT,STORAGE,GATEWAY,PLATFORM boundary;
+```
+
+读图规则：
+
+- 本图表达长期目标，不代表当前总 CLI、legacy crate 或现有生产镜像已经完成迁移；
+- 箭头表达业务流、公开 API 调用或边界交互，不表示每个 Domain 都是独立服务；
+- `core-runtime`、`core-maintenance`、`quant-lab` 是工件边界，不是业务 owner；六个生产 App 是独立 Cargo package，但共享一个生产镜像；
+- 生产 Domain 不依赖 Research、`quant/backtest` 或 `quant/analytics`；Research 只能通过稳定公开 API 复用生产业务实现；
+- Strategy、Portfolio、Risk、Execution 分别拥有自己的 Policy Snapshot 内容和校验；控制面只管理版本、生命周期、激活指针与 kill switch；
+- Domain 定义所需 Port，App 装配 Adapter；图中的 Storage/Gateway 连线不授权 App 或 Domain 绕过 Port 直接访问 SQL/SDK；
+- Web/Admin 与 Core 只通过版本化 Contract 和 owner API 协作，不共享数据库或 ORM；
+- 只有 `execution-worker` 可以把已持久化的 MutationPermit 和固定 payload 交给 Fenced Mutation Gateway；其他 App 不可达 raw mutation SDK；
+- `exchange-gateway` 同时是 `exchange × credential` 交易所配额的记账与准入 owner，mutation 优先于只读拉取；控制面的分级 Kill Switch 以已发布快照下发，数据面本地读取并 fail-closed；
+- `quant-lab` 的存储访问仅限 Research owner 事实、历史数据和 Evidence，不写生产 Order、Fill 或 Account 事实表，也没有生产部署和实盘 mutation 资格。
+
+### 4.2 目标物理目录
 
 ```text
 rust_quant/
 ├── apps/
 │   ├── control-api/                 # Core 控制面与 internal API
-│   ├── market-worker/               # 参考数据、行情、质量和快照
-│   ├── signal-worker/               # MarketSnapshot -> StrategySignal
-│   ├── account-worker/              # 余额、持仓、成交和持续风险投影
+│   ├── market-worker/               # 参考数据(fail-closed)与实时行情流(可降级),质量和快照
+│   ├── signal-worker/               # MarketSnapshot -> StrategySignal；含雷达 handoff 消费与订阅扇出
+│   ├── account-worker/              # 余额、持仓、成交、持续风险投影与 ExchangeSession readiness
 │   ├── execution-worker/            # ExecutionRequest -> 账户级 Portfolio/Risk -> OMS
 │   ├── reconciliation-worker/       # 对账、恢复任务和人工升级
 │   ├── schema-tool/                 # migration 与 schema 检查
@@ -97,10 +257,11 @@ rust_quant/
 │
 ├── crates/
 │   ├── domains/
-│   │   ├── market/
-│   │   ├── strategy/
+│   │   ├── control/                  # 控制面 owner:Release/激活指针、Readiness、分级 Kill Switch 已发布快照
+│   │   ├── market/                   # 内部 module 分 reference/(参考数据,fail-closed) 与 stream/(实时行情流,可降级)
+│   │   ├── strategy/                 # 含 signal 分发职责:匹配订阅 -> 扇出 ExecutionRequest(经 quant-web-client)
 │   │   ├── portfolio/
-│   │   ├── account/
+│   │   ├── account/                  # 含 ExchangeSession 子职责(会话 readiness 语义与 fail-closed 判定)
 │   │   ├── risk/
 │   │   ├── execution/
 │   │   ├── reconciliation/
@@ -113,12 +274,12 @@ rust_quant/
 │   │   └── analytics/
 │   │
 │   ├── contracts/                   # 一个 crate，内部按 owner/version 分模块
-│   │   └── src/{market,strategy,portfolio,account,risk,execution,reconciliation,research}/v1/
+│   │   └── src/{control,market,strategy,portfolio,account,risk,execution,reconciliation,research}/v1/
 │   │
 │   ├── adapters/
 │   │   ├── postgres/                # 一个 crate，内部按 owner 分模块
-│   │   │   └── src/{market,strategy,portfolio,account,risk,execution,reconciliation,research}/
-│   │   ├── exchange-gateway/        # 封装 crypto_exc_all；Fenced Gateway 独占 mutation capability
+│   │   │   └── src/{control,market,strategy,portfolio,account,risk,execution,reconciliation,research}/
+│   │   ├── exchange-gateway/        # 封装 crypto_exc_all；Fenced Gateway 独占 mutation capability；私有流连接生命周期/listenKey + 每 exchange×credential 配额记账
 │   │   ├── quant-web-client/        # 只调用 quant_web owner API
 │   │   ├── redis/
 │   │   ├── object-storage/
@@ -132,6 +293,7 @@ rust_quant/
 │       ├── security/
 │       └── testkit/                  # 只允许测试依赖
 │
+├── release-units/                   # core-runtime/core-maintenance/quant-lab 机器可读清单
 ├── migrations/                      # 单一有序 SQLx migration 流
 ├── tests/
 │   ├── architecture/
@@ -150,9 +312,16 @@ rust_quant/
 这是一张目标地图，不要求提前创建空目录或空 crate：
 
 - `contracts` 和 `postgres` 默认各保持一个 crate，通过内部 owner module 隔离；
+- Strategy 默认保持一个 crate；只有候选与已发布策略已经出现独立编译和发布生命周期证据时，才按第 3.2 节拆成 api/released/candidates 三个 catalog 级 package，不按单个策略拆包；
 - 只有真实编译隔离、重依赖、独立 owner 或发布需求出现时，才拆成更多 crate；
 - `risk-worker`、`portfolio-worker` 不是默认目录，只有运行证据支持时再增加；
-- Migration 保持一个 SQLx 可确定排序的目录，不按 owner 建立相互独立的迁移序列。
+- `domains/market` 内部必须区分 `reference`(参考数据,fail-closed)与 `stream`(实时行情流,可降级)两个 module,各自独立的新鲜度阈值与 readiness,不得共用一个健康判定(见 §5 表注);现阶段用 module 隔离即可,不拆 crate;
+- 雷达信号的"匹配订阅用户并扇出 ExecutionRequest"(§8.2 B1)是明确的编排职责,归 Strategy owner 的 signal 分发子职责,由 `signal-worker` 装配;它经 `quant-web-client` 调 Web owner API 查订阅与提交请求,不直连 Web 库,也不与 Strategy 的信号评估纯逻辑混在同一 module;
+- `ExchangeSession` 是 `domains/account` 内的子职责(会话 readiness 语义与 fail-closed 判定),底层连接/listenKey/配额机制复用 `adapters/exchange-gateway`,不拆独立 crate 或 worker(见 §5 表注与 [ADR-0012](adr/0012-multi-tenant-private-stream-management.md));ExchangeSession 的运行时状态(healthy/stale、最后消息墙钟时间、水位闭合时间、重连次数)是高频易变的运行时事实,持久化落 `adapters/redis`,进程重启后靠重连 + 快照闭合重建,不进 Postgres 事实表;
+- 雷达候选信号的 handoff 中转表归 **Strategy owner** 的持久化事实(信号候选是 Strategy 的事实,表名 `market_velocity_live_handoff` 只是历史命名),落 `adapters/postgres/strategy` 模块与单一 migration 流;`signal-worker` 消费它并经 `quant-web-client` 扇出;
+- `control` 是控制面 owner,拥有 Release/激活指针、Readiness 与分级 Kill Switch 已发布快照;它有独立的 `domains/control`、`adapters/postgres/control` 与 `contracts/control` 落点。控制面事实是数据面只读的已发布快照(§3.6),数据面本地读取并 fail-closed,不在热路径同步调用控制面 API;
+- `release-units/*.toml` 是 CI、镜像和部署合同的共同输入；生产镜像的 binary 集合必须与 allowlist 完全一致；
+- Migration 保持一个 SQLx 可确定排序的目录，不按 owner 建立相互独立的迁移序列。这一条以**当前单一 owner database 前提**成立；一旦某 owner（如 Market 海量 K 线）因容量、保留期或独立扩缩容出现拆分独立存储的实证需求，须另立 ADR 定义该 owner 的独立 migration 序列与切分边界，届时才解除本约束，而不是把单一 migration 流当作永久教条。
 
 `quant` 只保存 owner 无关的确定性机制：
 
@@ -168,15 +337,26 @@ Experiment、BacktestRun、Checkpoint、DatasetManifest、SimulationProfile 和 
 | 模块 | 拥有的事实与规则 | 明确不负责 |
 | --- | --- | --- |
 | Market | instrument、symbol、精度、交易能力、K 线、tick、盘口、资金费率、数据质量和市场快照 | 策略结论、资本分配、下单 |
-| Strategy | Strategy Definition、evaluator、registry、评估状态、信号、预测、置信度和证据截止时间 | 资金分配、账户读取、真实下单 |
+| Strategy | Strategy Definition、evaluator、registry、评估状态、信号、预测、置信度、证据截止时间，以及 signal 分发子职责（雷达候选信号的 handoff 持久化、匹配订阅用户并扇出 ExecutionRequest，经 quant-web-client 调 Web API） | 资金分配、账户读取、真实下单、直连 Web 库 |
 | Portfolio | 资本预算、策略组合、目标仓位、目标权重、冲突处理和净额合并 | 实际持仓、风险放行、订单协议 |
-| Account | 实际余额、持仓、敞口、保证金、PnL 和数据新鲜度 | 目标仓位、策略判断、订单提交 |
-| Risk | risk evaluation/decision、事前审批、持续敞口、回撤、保证金、保护要求、熔断和 RiskAction | 策略预测、交易所协议、订单持久化 |
-| Execution | AccountOpeningSlot、OrderIntent、ExecutionPlan、mutation attempt/permit、OMS、订单、成交、撤单、保护单和执行状态机 | 策略计算、资本分配、风险政策 |
+| Account | 实际余额、持仓、敞口、保证金、PnL、手续费/返佣/资金费现金流事件、账户投影数据新鲜度，以及 `ExchangeSession` 运行时 readiness（每 `exchange × credential` 的签名可用性、交易所冻结状态、User Stream 存活、signed preflight 结论与 fail-closed 判定） | 目标仓位、策略判断、订单提交、用户 API Key 的商业配置、底层连接/listenKey/配额机制 |
+| Risk | risk evaluation/decision、PreTradeSnapshot(下单前冻结的市场/账户/组合/规格证据)、事前审批、持续敞口、回撤、保证金、保护要求、熔断和 RiskAction | 策略预测、交易所协议、订单持久化 |
+| Execution | AccountOpeningSlot、ExecutionDecisionContextSnapshot、OrderIntent、ExecutionPlan、mutation attempt/permit、Outbox、OMS、订单、成交、撤单、保护单和执行状态机 | 策略计算、资本分配、风险政策 |
 | Reconciliation | 交易所差异、恢复任务、补偿编排和处置证据 | 绕过 owner 修改订单、账户或风险状态 |
-| Research | Experiment、BacktestRun、DatasetManifest、SimulationProfile、Checkpoint、ResearchEvidence 和证据发布 | 原始行情事实、Strategy Definition、生产订单/账户事实、live promote |
+| Research | Experiment、BacktestRun、DatasetManifest、SimulationProfile 配置实例、模拟账户初态、SimulationLedger(模拟事实,带 BacktestRunId,非 AccountProjection)、Checkpoint、ResearchEvidence 和证据发布 | 原始行情事实、Strategy Definition、生产订单/账户事实、模拟成交算法本身(归 quant/backtest)、live promote |
 
 `Reconciliation` 取代含义过宽的 `Operations`。日志、指标、审计传输和通知等通用技术能力属于 Platform 或 Adapter；运行恢复命令仍回到对应 domain owner，避免 Reconciliation 变成新的杂物筐。
+
+关于表内几个易混淆的边界：
+
+- Market 内含两类新鲜度与故障策略完全不同的子职责：**参考数据**（instrument、精度、tick size、最小下单量、上下架、交易能力）低频强一致，错误直接导致下单精度/数量算错，必须 fail-closed；**实时行情流**（tick、盘口、K 线）高吞吐可降级，延迟只影响信号质量。两者共用 Market owner 但必须有各自的新鲜度阈值与 readiness，不得用同一个健康判定覆盖；
+- `ExchangeSession` 是一等运行时事实，owner 归 **Account domain**，粒度是每 `exchange × credential` 一份，与 Account 的账户投影新鲜度**正交**（会话可在无任何持仓/余额变动时独立劣化，如 listenKey 过期或 Key 被冻结；余额也可在会话正常时因拉取滞后而 stale）。三方边界定死：
+  - **Web** 拥有用户 API Key 的**商业配置态**（§7.4 的 `credential_reference`、产品资格、启停），不拥有运行时健康；
+  - **`exchange-gateway` Adapter** 拥有**底层机制**——连接/listenKey 维护、签名探测、冻结错误归一、以及 §3.9 的配额记账（与 ExchangeSession 同挂 `exchange × credential` 维度）；
+  - **Account domain** 拥有**会话 readiness 语义与 fail-closed 决策**：聚合 gateway 上报的底层事实，判定某账户当前是否可安全新开仓；签名失效、交易所冻结、User Stream 断线或 preflight 未过时，依赖该账户的新开仓 fail-closed，不临时探测后放行；
+  - `ExchangeSession` 不拆独立 crate 或 worker：无独立扩缩容/发布证据，拆进程只会制造分布式会话状态一致性问题；它是 Account domain 内的子职责，底层机制复用 gateway；多租户私有连接的容量分阶段、分片/lease、降级态与恢复见 [ADR-0012](adr/0012-multi-tenant-private-stream-management.md) 与 [生产运行 §10.2](production-runtime.md)；
+- Portfolio 对用户 `strategy × symbol` combo 账户通常退化为“单目标直通”（一个 combo 对应一个仓位，净额/冲突/资本分配为恒等），完整的净额合并与资本预算主要服务自营/多策略共享账户；两种形态走同一 Portfolio API，不得因用户账户简单而绕过该阶段，也不必为其运行多策略资本分配算法；
+- 交易所配额记账（§3.9）归 `exchange-gateway` Adapter，不是某个 Domain 的业务事实，也不属于任何单个 worker。
 
 ## 6. Domain 内部标准结构
 
@@ -206,11 +386,40 @@ crates/domains/execution/src/
 
 详细 CRUD、事务和代码示例见[业务代码与数据访问放置规范](business-code-and-data-access.md)。
 
+### 6.1 Rust 业务代码形态
+
+Rust 不采用“所有业务逻辑都包装成 Service 对象”的 Java 式分层。先确定事实 owner，再根据身份、状态、不变量、纯度和 I/O 选择代码形态：
+
+| 业务特征 | 代码形态 | 约束 |
+| --- | --- | --- |
+| 有稳定身份、生命周期或跨字段不变量 | Entity/Aggregate：`struct`/`enum` + `impl` | 关键字段不得被调用方任意修改；状态变化使用业务动词并返回显式错误/事件 |
+| 无身份但有单位、范围或组合合法性 | Value Object：不可变 `struct`/`enum` | 构造时校验；不读取 I/O 或全局配置 |
+| 完整输入到输出的无状态确定性计算 | module 内自由纯函数 | 所有输入显式传入；不创建零字段 `*Calculator`/`*Service` 充当命名空间 |
+| 多个纯决策共享不可变、带版本配置 | Policy 对象：配置快照 + `evaluate`/`plan` | 不持有可变全局状态，不执行 I/O |
+| 跨事件维护滚动或生命周期状态 | 显式状态对象或纯 transition | 状态 identity 完整；backtest/live 调用同一 transition |
+| 编排读取、判断、持久化和事件 | Use Case 对象 | 只持有所需 Port；不承载数据库/SDK 实现 |
+| 数据库、HTTP、Redis、交易所技术状态 | Adapter 对象 | 实现消费方定义的 Port，不作业务决策 |
+| 存在真实多实现、进程内稳定 API 或测试替身 | Trait | 不为单一实现或“以后可能扩展”创建基类式 Trait |
+
+`impl` 只在“数据与行为必须一起保护语义”或“对象需要持有依赖/配置”时使用。仅为了 `Type::function()` 语法创建的零状态结构体应改为 module + function；一个函数同时修改 Strategy、Portfolio、Risk、Execution、Research 多个 owner 状态时，也不能通过移动进某个 `impl` 伪装成 Aggregate。
+
+一个 Domain 内部允许再按子领域切 module,以承载 SLA/职责显著不同的子部分,而不必立刻拆成独立 crate:
+
+- `domains/market` 内部分 `reference/`(参考数据,fail-closed)与 `stream/`(实时行情流,可降级),两者各自的 model/policies/ports,共享 domain 的 `api`;
+- `domains/account` 内部含 `exchange_session`(会话 readiness 语义)子领域,与账户投影正交;
+- `domains/strategy` 内部含 signal 分发子领域(handoff 消费、订阅匹配扇出),与信号评估纯逻辑分开 module,不混在同一处。
+
+子领域 module 只是 domain 内部组织,不改变"对外只暴露 domain `api`、跨 domain 不碰对方私有 module"的约束(§7.1);出现独立编译、重依赖或独立发布证据时,才升级为独立 crate。
+
+详细判定、代码示例和禁止模式见[业务代码与数据访问放置规范](business-code-and-data-access.md)。
+
 ## 7. 进程内与跨进程边界
 
 ### 7.1 同进程跨 Domain
 
 只允许依赖上游 Domain 的 `api` 或稳定公开类型。禁止访问其他 Domain 的私有 module、Repository Port、数据库 Row 或表。
+
+控制面依赖是一种特殊形态,要与"同步调 domain api"区分:数据面对 `control` owner 的依赖是**读取已发布的不可变快照**(Policy Snapshot、分级 Kill Switch),这些快照在交易热路径本地读取(§3.6),不是在热路径同步调用控制面的 api。数据面不得在下单热路径同步依赖控制面管理 API 的可用性;控制面不可用时,数据面按最近已发布快照运行或 fail-closed。
 
 ### 7.2 跨进程或跨仓库
 
@@ -221,18 +430,36 @@ crates/domains/execution/src/
 - Exchange 协议只经 `exchange-gateway -> crypto_exc_all`；
 - News 只能提供情报事实，不能直接生成可执行订单。
 
-### 7.3 Web `execution_tasks` 的目标语义
+跨仓库的雷达信号协作(§8.2)必须通过 Web internal API 完成：
+
+- **Core → Web 查询订阅**:`POST /api/commerce/internal/query-subscriptions`,传 `(strategy_slug, symbol)`,Web 返回订阅用户列表(包含 `credential_reference`、`risk_profile_ref` 等授权引用);Core 不直连 Web 订阅表;
+- **Core → Web 提交执行请求**:`POST /api/commerce/internal/execution-requests`,批量提交 `ExecutionRequest[]`,Web 写入 `execution_tasks` 并返回确认;Core 不直写 Web 表;
+- **News → Web 推送情报信号**:`POST /api/commerce/internal/news-signals`,带 `TRADE_SIGNAL_INTERNAL_SECRET` 鉴权,Web 同步查订阅、生成请求、写表、返回匹配结果;News 不直连 Web 或 Core 数据库。
+
+所有 internal API 必须带内部密钥鉴权,只允许 owner service 间调用,不对外暴露。
+
+### 7.3 同仓库异步跨进程(持久化中间媒介)
+
+除同进程直接调 `api`(§7.1)和跨仓库 HTTP Contract(§7.2)外,还有第三种边界:同一仓库、同一镜像内,两个进程通过**持久化中间媒介**异步通信——典型是雷达 handoff 中转表(生产进程写、消费进程读)、Execution 的 Outbox(owner 事务写、Dispatcher 读)。判断标准仍是"能否一起编译":写入方与读取方是不同进程、灰度期可能运行不同版本,所以它们之间不是同进程 `api`,而是一种 Contract。
+
+- 这类持久化媒介的 schema 必须版本化、向后兼容(N/N-1),按 owner 归属(handoff 归 Strategy owner、Outbox 归 Execution owner),写入单一 migration 流;
+- 写入方不得假设读取方与自己同版本;新增字段用可选/带默认,删除字段先经兼容窗口;
+- 消费方必须幂等(至少一次投递,重复/乱序可发生),并按 §8/§11 的恢复规则处理;
+- 不得用它绕过 owner:handoff/Outbox 只是同 owner 内部或明确 owner 的异步通道,不是跨 owner 直写他人事实表的后门。
+
+### 7.4 Web `execution_tasks` 的目标语义
 
 迁移期间，`quant_web.execution_tasks` 继续由 Web 拥有，但只表示“商业授权、订阅和凭证门禁后的执行请求/交接任务”，不是 OMS 订单事实。
 
 目标边界为：
 
 1. Web 根据会员、`strategy x symbol` combo、凭证和产品资格创建 `ExecutionRequest`；
-2. Web 将用户风险配置冻结成带版本引用或不可变授权约束；Web 不计算最终下单金额，也不生成 Core `RiskDecision`；
-3. Core 通过版本化 Contract 接收请求，为目标账户执行 Portfolio、Pre-trade Risk，并创建自己的 `OrderIntent`；
-4. Order、Fill、Protection 和 Reconciliation 的唯一事实源位于 Core；
-5. Web 只保存 Core 结果的用户展示投影，不再把 `exchange_order_results` 作为交易事实源；
-6. 迁移完成前，Core 对 Web 状态的更新必须调用 Web owner API，不得直接写 Web 表。
+2. Web 将用户风险配置冻结成精确 `risk_profile_ref + version` 或不可变授权约束；它是来源与授权引用，不是可直接执行的 Core 风险政策；
+3. Core 通过 quant-web-client/版本化 owner Contract 取得精确版本，由 Risk 校验单位、范围、默认值和账户/产品兼容性，幂等解析为不可变 `RiskPolicySnapshot`；缺失、撤销或不兼容时 Blocked，不直连 Web 数据库、不猜测“最新版本”或回退默认风险；
+4. Core 解析其余已发布政策，由 Execution 原子持久化 `ExecutionDecisionContextSnapshot` 与请求幂等身份，再为目标账户执行 Portfolio、Pre-trade Risk 并创建自己的 `OrderIntent`；
+5. Order、Fill、Protection 和 Reconciliation 的唯一事实源位于 Core；
+6. Web 只保存 Core 结果的用户展示投影，不再把 `exchange_order_results` 作为交易事实源；
+7. 迁移完成前，Core 对 Web 状态的更新必须调用 Web owner API，不得直接写 Web 表。
 
 `ExecutionRequest` 使用稳定 `execution_request_id`、`strategy_signal_id`、`execution_account_ref`、`credential_reference`、combo identity、`risk_profile_ref`、`risk_profile_version` 与 correlation/idempotency identity；如果携带授权约束，必须是创建请求时冻结的不可变快照。所有 ID 必须是 Contract 中有明确 owner 的类型；禁止使用 email、展示名称或可变 slug 推断交易账户身份，明文凭证不得进入 Contract。
 
@@ -243,8 +470,9 @@ flowchart LR
     M["MarketSnapshot"] --> S["StrategySignal"]
     S --> W["用户路径：Web ExecutionRequest"]
     S --> C["系统路径：Core ExecutionRequest"]
-    W --> P
-    C --> P
+    W --> CTX["ExecutionDecisionContextSnapshot"]
+    C --> CTX
+    CTX --> P["PortfolioTarget"]
     A["AccountSnapshot"] --> P
     P --> R["Risk owner 持久化 RiskDecision"]
     M --> R
@@ -271,6 +499,7 @@ flowchart LR
 MarketSnapshot
   -> StrategySignal
   -> ExecutionRequest（用户路径由 Web 授权；系统路径由 Core 运行配置产生）
+  -> ExecutionDecisionContextSnapshot（绑定四个已发布 Policy Snapshot）
   -> PortfolioTarget
   -> PreTradeSnapshot
   -> RiskDecision（Risk owner 按 risk_evaluation_id 已持久化）
@@ -285,8 +514,10 @@ MarketSnapshot
   -> ReconciliationResult
 ```
 
+- `ExecutionDecisionContextSnapshot` 由 Execution 拥有，只绑定各 owner 已发布且不可变的 Strategy、Portfolio、Risk、Execution planning 快照，不接管其政策内容；后续决策和恢复都引用同一 `context_id + context_hash`；
 - `PortfolioTarget` 表达目标，不代表允许交易；
-- `RiskDecision` 由 Risk owner 按 request、target/snapshot hash、policy version/generation 固定 evaluation identity；同一 evaluation 幂等，新评估使用新 generation；Execution 只保存不可变引用与审批证据；
+- `PreTradeSnapshot` 由 Risk owner 在评估前固定(冻结市场/账户/组合/instrument 规格证据),是 RiskDecision 的确定性输入,归 Risk;它是动态 Evidence 快照,不是可放宽的配置；
+- `RiskDecision` 由 Risk owner 按 Context hash、PortfolioTarget/PreTradeSnapshot hash、Market/Account/Instrument evidence 与 generation 固定 evaluation identity；同一 evaluation 幂等，新评估使用新 generation；Execution 只保存不可变引用与审批证据；
 - `OrderIntent` 只能由有效审批生成；
 - `ExecutionPlan` 固定拆单、顺序、时效和交易所能力，`ProtectionPlan` 固定保护方式、数量语义、最大未保护窗口和失败动作；两者必须与 `SubmitPending`、幂等和提交 Outbox 一起持久化，不能只留在内存；
 - `SubmitPending` 表示可恢复的持久提交任务，不表示已向交易所发送；Dispatcher 不得静默重算数量、价格、保护方案或 client identity；
@@ -297,23 +528,125 @@ MarketSnapshot
 - `AccountProjection` 只由交易所余额、仓位、成交和资金事件更新；
 - `Reconciliation` 只能发送 typed command 请求 owner 恢复。
 
+### 8.2 多信号源触发与汇流
+
+上述标准交易链路支持三种触发源,它们在信号产生方式与用户匹配时机上不同,但从 `ExecutionRequest` 开始都汇入同一套执行链路(Account → Risk → Execution):
+
+#### 触发源 A:用户订阅定期触发
+
+- **触发方式**:用户在 Web 订阅了 `strategy × symbol` combo,Core 按订阅清单定期评估策略;
+- **信号产生**:Strategy owner 对已知订阅的 combo 生成 `StrategySignal`;
+- **用户绑定时机**:触发时已知"这是给订阅此 combo 的用户的";
+- **ExecutionRequest 生成**:Web 根据订阅关系、会员资格、API Key 配置,为每个订阅用户生成独立的 `ExecutionRequest`,写入 `execution_tasks`;
+- **特点**:信号与用户在评估时已绑定,一对一生成请求,无需事后匹配。
+
+#### 触发源 B1:Market Velocity 动量雷达(Core 内部广播)
+
+- **触发方式**:Core 的 `signal-worker` 运行 `market-velocity-live-handoff`,广播式扫描全市场(或指定币种列表),对每个币种评估动量/反转策略;
+- **信号产生**:Strategy owner 生成候选信号 `(strategy_slug, symbol, direction, confidence, ...)`,写入 Core 自己库的 handoff 中转表(归 Strategy owner 持久化,`adapters/postgres/strategy`);
+- **用户绑定时机**:信号产生时**不知道给谁**,由 handoff 消费侧事后查询订阅并匹配;
+- **消费与匹配**(Core handoff 消费循环):
+  1. 轮询 handoff 表,读出候选信号;
+  2. 调用 **Web internal API** `POST /internal/query-subscriptions`,传 `(strategy_slug, symbol)`,查询"谁订阅了这个 combo";
+  3. Web 返回订阅用户列表 `[{user_id, credential_reference, risk_profile_ref, execution_account_ref, ...}]`;
+  4. Core 对每个订阅用户,组装信号 + Web 返回的授权引用,生成独立的 `ExecutionRequest`;
+  5. Core 调用 **Web internal API** `POST /internal/execution-requests`,批量提交请求;Web 写入 `execution_tasks`,返回"已接收 N 个";
+  6. Core 标记 handoff 信号为"已处理"。
+- **特点**:信号广播产生 → 事后匹配订阅用户 → 扇出 N 个请求。Core 不直连 Web 数据库,只通过 Web owner API 查询商业授权事实并提交请求。
+
+#### 触发源 B2:News 新闻雷达(跨仓库推送)
+
+- **触发方式**:`rust_quant_news` 的 `scheduler` 抓取新闻、MiniMax AI 分析,判断可执行信号;
+- **信号产生**:News owner 生成信号 `{symbol, direction, confidence, news_id, analysis, ...}`;
+- **用户绑定时机**:信号产生时**不知道给谁**,由 Web 接收侧匹配;
+- **推送与匹配**(News → Web):
+  1. News 调用 **Web internal API** `POST /internal/news-signals`,带 `TRADE_SIGNAL_INTERNAL_SECRET` 鉴权,推送信号;
+  2. Web 在同一 HTTP 请求的处理流程里(同步):
+     - 查询自己的订阅表,找出"订阅了此策略×币种 combo 且会员有效、API Key 已配置"的用户;
+     - 对每个订阅用户,生成独立的 `ExecutionRequest`,写入 `execution_tasks`;
+     - 返回 News 一个确认 `{received: true, matched_users: N, execution_requests_created: N}`;
+  3. News 收到确认后,标记信号为"已提交",后续不再管。
+- **特点**:News 只负责情报信号,不拥有"谁订阅了什么"的商业事实。信号经 Web(商业事实 owner)匹配订阅、生成请求。News 不直连 Web 或 Core 数据库。
+
+#### 汇流点:`execution_tasks` → 统一执行链路
+
+三种触发源无论通过何种路径,最终都把 `ExecutionRequest` 写入 Web 的 `execution_tasks` 表。从这一刻起,后续链路完全一致:
+
+- `execution-worker` 轮询 `execution_tasks`,拿到请求;
+- 根据 `credential_reference` 和 `execution_account_ref` 读取 Account 投影(第 4 站);
+- 解析 `risk_profile_ref` 为不可变 `RiskPolicySnapshot`,冻结 `ExecutionDecisionContextSnapshot`,进入 Risk 审批(第 5 站);
+- 批准后进入 Execution 下单/保护/回流(第 6 站)。
+
+**execution-worker 不知道、也不关心这个请求是"用户订阅定期触发的"、"动量雷达扫出来的"、还是"新闻 AI 推的"**——它只看:有一个合法的 `ExecutionRequest`,带授权引用,走标准链路。
+
+#### 边界约束与 owner API
+
+- **Core 不直连 Web 数据库**:动量雷达消费侧查订阅、提交请求,都通过 Web internal API,不跨库直连 `quant_web.strategy_symbol_subscriptions` 或 `quant_web.execution_tasks`;
+- **News 不直连 Web 或 Core 数据库**:新闻信号只推给 Web API,由 Web 自己查自己的订阅表、写自己的 `execution_tasks`;
+- **Web 的"订阅匹配"是商业事实的唯一 owner**:无论谁问"这个 combo 谁订阅了",答案只能来自 Web,其他服务不能绕过 Web 自己猜或自己查;
+- **三种触发源都不跳过 Risk 审批**:`ExecutionRequest` 只是"授权请求",不是"已批准订单"。后续 Account 新鲜度、ExchangeSession readiness、分级 Kill Switch、事前 Risk 门禁一样都不能少。
+
 ## 9. 策略定义、研究证据与发布分离
 
 原“Strategy Manifest”拆为五个明确对象，并分配给两个 owner，避免把可变生命周期写进不可变定义：
 
 | 对象 | 可变性 | 内容 |
 | --- | --- | --- |
-| `StrategyDefinition` | 不可变 | strategy key/version、输入要求、参数 schema、输出语义、支持范围、执行与保护能力 |
+| `StrategyDefinition` | 不可变 | strategy key/version、输入要求、entry/exit 参数 schema、输出语义、支持范围、执行与保护能力 |
 | `StrategyArtifact` | 不可变 | 代码 revision、构建/模型 artifact hash、参数 schema 与运行兼容能力 |
 | `ResearchEvidence` | 不可变 | Experiment/Run、DatasetManifest、样本、成本、模拟精度、回测和验证证据 |
 | `StrategyRelease` | 显式状态迁移 | Research、Paper、Shadow、Canary、Live、Retired 与批准/回滚记录 |
-| `StrategyRuntimeSnapshot` | 发布后不可变 | 某次运行实际使用的 definition、参数、portfolio/risk 版本和 release generation |
+| `StrategyRuntimeSnapshot` | 发布后不可变 | definition/artifact/release generation、entry/exit 参数、evaluator state schema、输入要求与策略能力 |
 
 Strategy 拥有 Definition、StrategyArtifact、Release 和 RuntimeSnapshot；Research 拥有 Experiment、Run、DatasetManifest、Checkpoint 和 ResearchEvidence。已有对象不得覆盖。Promote 只引用已完成 Evidence，回滚、停用只改变 Release 或创建新 Runtime Snapshot，不修改历史事实。
 
+**版本演进 vs 新策略的判定规则(不可绕过)**:已上线或已有准生产证据的策略默认禁止原地覆盖,任何改动按影响面二选一:
+
+- **保留 `strategy_key`、新增独立 `version`**:仅当改动不改变策略家族与执行/风控契约——即新增/调整过滤、阈值、指标参数,而入场/出场语义、风险模型、信号 payload 含义、支持交易对/周期、执行门禁、用户可见产品语义全部不变;
+- **视为新策略(新增 `strategy_key`/`strategy_slug` 或等价标识)**:只要改动影响入场/出场语义、风险模型、信号 payload 含义、支持范围、执行门禁或用户可见产品语义之一;新策略必须先在 backtest/paper/read-only shadow 运行并取得 Evidence,显式 promote 后才 live;
+- 两种情况都**绝不允许写回 `default` 或任何丢失版本标识的路径**。判定存疑时按"新策略"处理(更保守)。
+
+此判定与 [根仓库 CLAUDE.md 的策略版本纪律] 一致,是同一条红线在架构文档中的权威表述。
+
 Strategy evaluator、Portfolio policy 和 Risk policy 必须确定性可重放；backtest、paper、shadow、canary 和 live 复用同一业务实现，只替换 Market、Account 和 Exchange Adapter。
 
-### 9.1 策略评估状态
+“同一业务实现”不是“两个实现读取相同 JSON”或“最后 PnL 接近”，而是：
+
+- Strategy evaluator/exit policy、Portfolio policy、Risk policy/final-stop constraint 和 Execution planning 在所有运行模式下解析为同一 Rust symbol/API；
+- Strategy、Portfolio、Risk、Execution 分别发布自己拥有的强类型 Policy Snapshot；运行入口不得把同一 JSON 分别反序列化成语义重叠的 backtest/live 配置；
+- Strategy 输出候选失效价、退出意图/候选止盈计划和解释证据；Risk 使用冻结政策选择不可放宽的最终止损与风险边界并批准/缩减数量，不替 Strategy 发明盈利目标；Execution 把 Strategy exit intent 与 RiskDecision 合并为可执行且可恢复的 `OrderPlan`/`ProtectionPlan`；
+- `trade_fee`、slippage、funding 和 candle 内路径属于 `SimulationProfile`，不能混入账户风险配置；账户资金比例属于 Portfolio，真实 leverage/margin mode 由 Risk 审批、Execution 实现；`SimulationProfile` 有两层归属:**配置实例**(具体 fee/slippage/funding/latency 参数值)归 Research owner,是 ResearchRunSpec 的一部分;**模拟成交/撮合/费用/滑点/资金费的算法机制**归 `quant/backtest`(owner 无关的确定性纯机制),Research 引用它但不重写；
+- live、shadow 和 Research 的差异只能来自显式 Adapter 输入或 SimulationProfile，不能来自 `if live`/`if backtest` 业务分支、环境变量或第二套 Calculator/Service。
+
+### 9.1 分层运行快照与完整决策上下文
+
+“完整运行配置”不是一个万能 Strategy 对象，而是以下三层不可变声明：
+
+```text
+Domain Policy Snapshots
+  StrategyRuntimeSnapshot
+  PortfolioPolicySnapshot
+  RiskPolicySnapshot
+  ExecutionPlanningPolicySnapshot
+
+ExecutionDecisionContextSnapshot
+  = 某个 ExecutionRequest 对四个 Published Policy Snapshot 的稳定绑定
+
+ResearchRunSpec
+  = DatasetManifest + 四个 Policy Snapshot + SimulationProfile
+    + 模拟账户初态 + Clock/Seed
+```
+
+- Strategy 只拥有策略定义、entry/exit 参数、状态 schema、输入要求和能力，不拥有用户账户、凭证或 risk profile；
+- Portfolio 拥有 allocation、净额、容量和冲突政策；Risk 拥有账户风险、最大损失、敞口、leverage/margin、final-stop 与保护要求；Execution 拥有订单、TIF、拆单、价格保护、部分成交和 ProtectionPlan 生成政策；
+- Web 的 risk profile 是来源和授权引用，必须先由 Core Risk 解析成不可变 `RiskPolicySnapshot`；
+- Execution 在 owner transaction 中把 Context 与请求 intake/幂等身份一同持久化；`RiskDecision`、`OrderIntent`、`ExecutionPlan`、`ProtectionPlan`、attempt 与恢复事件都引用同一 `context_id + context_hash`；
+- MarketSnapshot、AccountSnapshot、InstrumentRulesSnapshot 和 observed time 是动态 Evidence，不是配置；相同 Context 在不同账户事实下产生不同 RiskDecision 属于正确行为；
+- 所有 Snapshot、Context 和 RunSpec 必须有 schema version、单位、默认值展开、规范排序、Decimal scale、内容 hash 与 N/N-1 兼容测试；价格、数量、费用和保证金不得以未量化 `f64` 参与 hash。
+
+完整字段、更新、撤销与 exact parity 语义以 [ADR-0011](adr/0011-layered-runtime-snapshots-and-decision-context.md) 为准。
+
+### 9.2 策略评估状态
 
 有滚动指标或增量窗口的策略必须显式拥有 `StrategyEvaluationState`，不能依赖进程全局 Map 或仅由 `symbol + period + strategy_type` 拼出的缓存键。
 
@@ -327,16 +660,17 @@ StrategyEvaluationStateKey
 - Runtime Snapshot 变化必须创建新的评估状态，禁止新旧参数共用指标缓存；
 - backtest 的 EvaluationScopeId 是 BacktestRunId；live 使用 release/deployment generation；并行实验不得共享可变状态；
 - Market 负责 confirmed、sequence、去重、缺口和新鲜度；Strategy 只负责 evaluator checkpoint、滚动指标和最后已处理市场版本；
-- live 可使用 Redis/Postgres Adapter 保存 checkpoint，backtest 使用内存 Adapter，但二者调用相同状态迁移；
+- live 策略 checkpoint 是高频易变的运行时状态,落 `adapters/redis`(与 ExchangeSession 运行时状态同类,不进 Postgres 事实表);backtest 使用内存 Adapter;二者调用相同状态迁移;
 - 状态恢复后必须验证 Runtime Snapshot、数据流版本和最后证据时间，无法证明连续时重新预热或 fail-closed。
 - Evaluation State 是 StrategyEvaluator 的内部输入输出，不是 Signal 后面的独立交易阶段。
 
-### 9.2 Research 控制流程
+### 9.3 Research 控制流程
 
 ```text
 quant-lab
   -> Research::StartBacktestRun
-  -> 冻结 DatasetManifest、RuntimeSnapshot、Policy 版本、SimulationProfile 和 Seed
+  -> 冻结 ResearchRunSpec
+  -> 为每个模拟账户/请求构造 ExecutionDecisionContextSnapshot
   -> Research::ExecuteBacktest
   -> checkpoint / complete / fail
   -> Evidence 原子可见发布
@@ -344,7 +678,7 @@ quant-lab
 
 Market 拥有历史行情事实；Research 拥有 point-in-time 选择、universe membership、数据指纹和 Run 生命周期。长期或多币种数据通过确定性 historical event stream 读取，不要求把全部行情一次性装入内存。
 
-### 9.3 ResearchBar 事件循环
+### 9.4 ResearchBar 事件循环
 
 ```text
 同一 decision_time 的全部 HistoricalMarketEvent
@@ -363,7 +697,7 @@ Market 拥有历史行情事实；Research 拥有 point-in-time 选择、univers
 
 `SimulationLedger` 是 Research 模拟事实，不是 AccountProjection。它只产生 Portfolio/Risk 可消费的模拟 AccountSnapshot read model，所有身份带 BacktestRunId，禁止写入生产 Order/Fill/Account 表。
 
-### 9.4 分级模拟与 Parity
+### 9.5 分级模拟与 Parity
 
 - `ResearchBar`：现有 Vegas/NWE 参数回测；精确复用 Strategy、Portfolio、Risk 和 OrderPlan，成交/PnL 由显式撮合模型决定；
 - `PaperEvent`：模拟 Ack、PartialFill、Reject、Cancel、Protection 和延迟，复用 Execution 纯状态迁移；
@@ -371,19 +705,62 @@ Market 拥有历史行情事实；Research 拥有 point-in-time 选择、univers
 
 Signal、PortfolioTarget、RiskDecision、OrderIntent/OrderPlan 在相同输入下必须逐层 parity；Fill/PnL 只能在相同 SimulationProfile 下重放一致，不能宣称与真实交易所完全相同。完整分配见 [Vegas 与现有回测主链迁移实战](vegas-backtest-migration.md)。
 
-### 9.5 Evidence 发布
+Parity fixture 必须冻结并记录：
+
+```text
+ResearchRunSpec
+ExecutionDecisionContextSnapshot
+MarketSnapshotRef / AccountSnapshotRef / InstrumentRulesSnapshotRef
+StrategyEvaluationState before
+SimulationProfile（仅模拟成交相关）
+Clock / Seed
+```
+
+同一 fixture 至少生成可规范序列化和比较的 `StrategySignal`、`StrategyEvaluationState after`、`PortfolioTarget`、`RiskDecision`、`OrderIntent`、`OrderPlan`、`ProtectionPlan` 与决策 trace。任一层首次出现差异时在该层失败，禁止继续用最终成交或 PnL 抵消前序差异。
+
+只有四个 Policy Snapshot hash、Context hash、动态 Evidence、EvaluationState before、Clock 与业务 API 全部相同时，才称为 exact business parity；否则只是 scenario comparison。`SimulationProfile` 变化不得改变 Signal、Target、RiskDecision、ExecutionPlan 或 ProtectionPlan。
+
+### 9.6 Evidence 发布
 
 对象存储与 Postgres 不宣称全局原子：先以内容哈希幂等上传不可变大对象，再由 Research owner 单一数据库事务发布 EvidenceManifest、指标、引用、幂等记录和 Completed 状态。只有 Completed Evidence 可被查询或 Strategy Release 引用；孤立对象由 GC 清理。
 
 ## 10. 数据、时间和数值
 
-- 指标与统计内部可以使用 `f64`；价格、数量、费用、保证金和订单参数使用 Decimal 或交易所固定精度类型；
-- 策略时间来自注入的 Clock 和 MarketSnapshot，不读取系统当前时间；
+- 指标与统计内部可以使用 `f64`；价格、数量、费用、保证金、盈亏和订单参数使用 Decimal 或交易所固定精度类型。金额类型必须**在 Domain 实体/值对象层就用 Decimal 定义**，不得让实体用 `f64` 定义金额再向 Risk/Execution 蔓延成 f64↔Decimal 混用带；止损价、下单数量、保证金率等进入真实挂单的计算全程 Decimal，禁止 f64 中间态引入累积误差；
+- 系统区分两个时间源，不得互相混用：`DecisionTime` 来自注入 Clock 和 MarketSnapshot 的事件时间，用于策略决策、评估状态与 parity，绝不读取系统当前时间；`WallClock` 是运行时真实墙钟，用于 lease/`MutationPermit` 过期、最大未保护窗口、Account stale 判定和对账调度，绝不接注入 Clock，也不参与 parity hash；
+- 手续费、返佣和永续资金费是 Account 的持续现金流事件，直接影响 PnL 与持续 Risk 的保证金判定，必须作为 AccountProjection 的一类输入投影，与回测侧 `SimulationProfile` 的 fee/funding 模型职责对称但互不替代；
 - Market 数据必须经过标准化、序号、去重、乱序、缺口和新鲜度检查；
 - 订单、成交、余额和持仓保留 source、exchange timestamp 与 observed timestamp；
 - 研究产物记录数据指纹、样本区间、费用、滑点、资金费、代码 revision 和所有政策版本；
 - 高频查询必须有索引、扫描范围、容量和退化证据；
 - 大体积历史行情和研究产物经 Port 使用合适存储，不把存储技术泄漏进 Domain。
+
+### 10.1 类型边界:无类型 JSON 与 SDK DTO 只活在 Adapter
+
+无类型 blob 和外部协议类型是迭代中最易穿透全层的坏味道(legacy 里 domain 端口直接返回 `serde_json::Value`、`okx::dto::*` 一路穿到 execution/market),必须在边界收敛:
+
+- **Domain 的 Port trait 不得以 `serde_json::Value` 作为入参/返回/字段**表达业务数据；Port 用领域类型(Decimal 金额、值对象、枚举)命名业务动作。无类型 JSON 只允许出现在 Adapter 内部解析与 Contract 的 wire 层;
+- **交易所 SDK DTO(`okx::dto::*`、`crypto_exc_all` 的 raw 类型)禁止跨出 Adapter**;`exchange-gateway` Adapter 负责把 SDK DTO 映射为 Domain 类型,业务 crate(Strategy/Risk/Execution/Portfolio/Account)不得直接 `use` SDK DTO,否则换交易所要重写业务层;
+- **数据库 Row 类型不出 Adapter**;Postgres Adapter 把 Row 映射为 Domain model,Domain/Use Case 不见 sqlx Row;
+- Domain 实体确需保留原始载荷时(如审计取证),用明确命名的不可变 `raw_payload` 字段并注明"仅存证、不参与决策",不得让决策逻辑从 `Value` 里按字符串 key 取业务字段。
+
+### 10.2 错误处理:失败必须显式,不得压平或在热路径 panic
+
+- **交易/执行/风控热路径禁止 `.unwrap()`/`.expect()`/`panic!`**;下单数量、订单 key、止损价、保证金等计算的 `Result`/`Option` 必须显式处理并返回错误,实盘路径任何 panic 都是资金安全事故;
+- **禁止用 `unwrap_or_default()`/`.ok()` 压平业务错误**:失败的余额/持仓/金额解析变成 `0.0`/空集合会让 Risk 误判"无仓位无敞口"而放行;金额与仓位相关的 Result 必须向上传播,由 Use Case 决定 fail-closed;
+- 未支持的交易所/分支用显式 `Err` 表达并 fail-closed,不用 `panic!` 表达"不该走到这";
+- 后台任务(scheduler/worker)的关停信号发送与 join 结果不得 `let _ =` 静默丢弃,任务 panic/失败必须被感知并记录。
+
+### 10.3 数据、迁移、配置与凭证纪律
+
+以下是 legacy 里最伤数据一致性、可复现构建和密钥安全的坏习惯,新架构与迁移期一并堵住:
+
+- **单一 schema 真相来源**:表结构只由 `migrations/` 定义,禁止运行时 DDL(代码里 `CREATE TABLE IF NOT EXISTS`/`ALTER`)与旁路整库脚本(`sql/*.sql` 一次性建库)并存;分表用声明式分区或统一注册器,不在首次访问时即时建表。legacy 里迁移(40 表)/ schema_ensure 脚本(44 表)/ 运行时 DDL 三套并存且已不一致,靠 contract test `.contains()` 硬顶,必须收敛为一处;
+- **迁移严格 append-only + 可回放 + 可回滚**:已应用的迁移禁止事后改写(sqlx checksum 会崩、环境间静默漂移);迁移必须能在空库从零重放(清理 MySQL 语法等不可移植遗留);破坏性变更提供回滚路径或明确的前向修复迁移;新表新列必须有数据库原生 COMMENT;
+- **一表一行模型一归属**:同一张表的 `FromRow` 结构只在其 owner 的 Postgres Adapter 定义一次,禁止多个 crate 各自定义(legacy 里 `SwapOrderEntity` 定义 3 次);表名用集中常量,不散落字面量,不留旧名别名(如 `strategy_config` vs `strategy_configs`);
+- **SQL 纪律**:禁止 `SELECT *`(列随迁移漂移即出错)、无 WHERE 的 UPDATE/DELETE、字符串拼接列值;分表名拼接必须走集中的白名单校验;多步写(建表+COMMENT、审计+状态更新)包在单一事务里;
+- **集中类型化配置**:配置由 App/Platform 层集中解析为强类型 Config 并注入,业务 crate 不散读 `std::env::var`;每个配置项单一登记处、单一默认值;提供配置清单(`.env.example`);legacy 里 616 次 env 读散落 163 文件,默认值各异,是隐藏必需变量的温床;
+- **凭证是受保护类型,不是普通字符串**:api_key/secret/passphrase 用 redacting 包装类型(自定义 `Debug` 脱敏、禁默认 `Serialize`),不得裸 `String` + `derive(Debug, Serialize)`;凭证不进 Domain 实体与 Contract(只传 `credential_reference`);内部鉴权 secret 无安全默认值(禁 `local-dev-secret` 之类进部署产物),缺失即 fail-closed。
 
 ## 11. 执行保护与恢复底线
 
@@ -394,6 +771,8 @@ Signal、PortfolioTarget、RiskDecision、OrderIntent/OrderPlan 在相同输入�
 - startup 必须先订阅并缓冲 User Stream，再合并 signed snapshot/query watermark 并补 gap；闭合前 NotReady 且 Dispatcher 禁用；
 - 风险降低旁路必须可证明 reduce-only，并先冻结风险增加 claim、处理已有开仓订单和迟到 Fill；
 - 无法在规定时间证明保护有效时，停止同账户新开仓并触发显式 RiskAction；
+- Account owner 的 `ExchangeSession` readiness 失败（签名失效、交易所冻结、User Stream 断线、preflight 未过）时，依赖该账户的新开仓 fail-closed，不得临时探测后放行；
+- 开仓前必须核对 §3.8 的分级 Kill Switch 已发布快照，任一命中作用域停用即拒绝新开仓；控制面不可用时按最近已发布快照 fail-closed；
 - 所有恢复操作沿用原订单身份、状态机、lease 和审计链路。
 
 详细状态与时序见[生产运行与恢复](production-runtime.md)。
@@ -403,6 +782,19 @@ Signal、PortfolioTarget、RiskDecision、OrderIntent/OrderPlan 在相同输入�
 - 新增代码前先写“owner 与放置声明”；
 - 新功能从 command、query 或 event-consumer 三种垂直切片模板开始；
 - 禁止新增泛型 `Repository<T>`、`BaseService`、`update_by_id`、`save_json` 或跨 owner SQL；
+- 禁止跨仓库直连数据库:Core 不得连接 `quant_web`/`quant_news`,News/Web 不得连接 `quant_core`;跨仓库读写只走 owner internal API + quant-web-client 等 Adapter(§7.2、§8.2);历史跨库直连只能作为标记的待迁移 legacy,不得新增或扩展;
+- 禁止在 Strategy evaluator、Portfolio/Risk/Execution planning 等决策纯逻辑里读取系统当前时间(`SystemTime::now`/`Utc::now`/`Instant::now`)或随机源;`DecisionTime` 必须来自注入 Clock,`WallClock` 只允许出现在运行时时效路径(lease/permit/心跳/stale/调度),不进决策与 parity(§10);
+- 禁止 Domain 层出现 `serde_json::Value` 业务字段/端口签名,禁止业务 crate `use` 交易所 SDK DTO(`okx::*`)或 sqlx Row 类型,类型映射只在 Adapter 边界(§10.1);
+- 交易/执行/风控热路径禁止 `.unwrap()`/`.expect()`/`panic!` 与金额相关的 `unwrap_or_default()`/`.ok()` 压平(§10.2);金额类型在 Domain 层用 Decimal 定义,禁止 f64 定义金额字段(§10);
+- 默认收敛可见性:Domain/业务 crate 对外只经 `api`/`lib.rs` 重导出稳定类型,内部 module 用 `pub(crate)` 或私有,禁止 `pub mod` 全敞开 + 大面积 `pub use` glob re-export 制造隐式耦合;
+- 测试必须确定性且带断言:禁止把参数扫描/研究脚本塞进 `#[test]` 再 `#[ignore]` 沉淀,禁止只 `println!` 无断言的"假测试";依赖真实交易所/网络/生产 DB 的测试归 integration 且不作为默认 CI 门禁;
+- 决策开关必须是带规范 hash 的显式配置输入,禁止在热路径读 `std::env::var`(见 §10 与坏味道防线);交易标的范围、风控阈值等业务规则走配置,不硬编码进逻辑常量;
+- 表结构只由 `migrations/` 定义(禁运行时 DDL 与旁路整库脚本并存),迁移 append-only、可空库重放、新表新列带 COMMENT,一表一 `FromRow` 归属;禁 `SELECT *` 与拼接列值 SQL(§10.3);
+- 凭证用 redacting 包装类型,禁裸 `String` + `derive(Debug, Serialize)`,不进 Domain/Contract;内部鉴权 secret 无安全默认值,缺失 fail-closed(§10.3);
+- 后台任务经统一 supervisor(JoinSet/结构化并发)管理,禁裸 `tokio::spawn` 丢弃 JoinHandle 的 fire-and-forget;关停走 graceful shutdown,`process::exit` 只在单一顶层退出点;
+- 跨进程/跨仓库 internal API 显式版本化(`/v1/` 或 apiVersion 字段),可选字段带 `#[serde(default)]` 兼容,版本不混进业务字符串;handoff/Outbox schema 按 §7.3 版本化 N/N-1;
+- 关键路径(下单、成交、对账、lease、readiness)必须有 metrics 埋点、贯穿式 tracing span 与标准 `/health` 端点;错误统一分类 `Retryable`/`Fatal`;重试/退避/幂等去重复用统一封装,不各处手写;
+- 依赖版本纪律:workspace 内统一 `workspace = true`,git 依赖钉 `rev`,不引入不可复现的浮动版本;
 - `cargo xtask arch-check` 采用渐进 ratchet：先禁止新增违规，再逐步清理 legacy，不能一次让全仓 CI 永久变红；
 - 静态门禁之外，业务不变量由单元测试，SQL/事务由集成测试，跨进程兼容由 contract test，故障恢复由 recovery test 证明；
 - 子目录 `AGENTS.md` 只记录相对本目录的增量规则，并链接本目录权威文档，禁止复制整套规则造成漂移。
@@ -411,20 +803,28 @@ Signal、PortfolioTarget、RiskDecision、OrderIntent/OrderPlan 在相同输入�
 
 ## 13. 完成标准
 
-- 新策略只修改 Strategy、Definition、Registry、StrategyArtifact 和测试；研究结论由 ResearchEvidence 记录；
+- 新候选策略只修改 Strategy candidates catalog、策略测试和 Research Experiment；研究结论由 ResearchEvidence 记录，不进入生产 App 依赖图；
+- 候选策略晋级时才进入 Strategy released catalog，并创建/冻结 Definition、Artifact、Release、RuntimeSnapshot，触发生产构建与 parity；
 - 新分配方法只修改 Portfolio，不修改 Strategy 或 Exchange Adapter；
 - 新交易所只修改 `crypto_exc_all`、exchange-gateway、能力合同和适配测试；
 - 数据库 CRUD 的业务意图、Port、SQL 与事务位置可被唯一定位；
 - Web 的商业执行请求与 Core 的订单事实不再混淆；
 - 成交能够幂等更新 Account 并触发持续 Risk；
 - 部分成交、保护缺失、撤单竞态和未知结果有确定恢复协议；
+- live 开仓路径经测试证明:没有经过验证的保护/止损计划时必被拒绝,不存在裸单路径(§11、根 CLAUDE.md 实盘安全);
+- 分级 Kill Switch 经测试证明:任一命中作用域停用即拒绝新开仓,控制面不可用时数据面按最近已发布快照 fail-closed,上级停用不被下级恢复覆盖(§3.8);
+- Account owner 的 `ExchangeSession` readiness 失败(签名失效、交易所冻结、User Stream 断线、preflight 未过)时,依赖该账户的新开仓经测试证明 fail-closed,不临时探测后放行(§5、§11、ADR-0012);
 - 控制面不可用不会产生无版本交易；
 - CI 能拒绝新增非法依赖、跨 owner SQL、未版本化 Contract 和 testkit 生产依赖；
+- `core-runtime`、`core-maintenance`、`quant-lab` 有独立 Release Unit Manifest；生产镜像只包含六个生产 App binary，Research-only 变更不能获得生产部署资格；
 - golden vertical slice 经 shadow/parity/recovery 验证后再迁移下一切片；
-- Vegas 在相同 DatasetManifest、RuntimeSnapshot、Portfolio/Risk 版本、SimulationProfile 和 Seed 下可确定重放；
+- Vegas 在相同 ResearchRunSpec、ExecutionDecisionContext、动态 Evidence 与 EvaluationState before 下可逐层确定重放；
 - 多币种回测改变 symbol 输入顺序后，Portfolio/资金结果必须字节一致；
 - ResearchBar、PaperEvent 与 RecoveryHarness 不互相夸大覆盖范围；
 - Strategy evaluator 不接收账户风险配置，`position_leverage` 等历史混合字段完成语义拆分。
+- backtest、paper、shadow、canary、live 的策略 entry/exit、组合、风险/final-stop 和 OrderPlan 指向同一业务实现；exact parity 必须同时证明四个 Policy Snapshot、Context 与动态 Evidence identity 一致；
+- 新增仅 Research 使用的实验编排或模拟机制不会进入生产 App 依赖图；共享 Domain 规则变化仍会触发生产构建和 parity 门禁；
+- 新增代码能够按身份、状态、不变量、纯度和 I/O 唯一选择 Entity/Value Object、纯函数、Policy、Use Case、Port 或 Adapter，不新增零状态万能 Service/Calculator。
 
 ## 14. 相关决策
 
@@ -437,3 +837,6 @@ Signal、PortfolioTarget、RiskDecision、OrderIntent/OrderPlan 在相同输入�
 - [ADR-0007：Owner-scoped 数据访问与事务边界](adr/0007-owner-scoped-persistence-and-transaction-boundaries.md)
 - [ADR-0008：回测复用 Domain API 的双层 Quant 依赖（已被取代）](adr/0008-backtest-reuses-domain-apis.md)
 - [ADR-0009：Research Domain、纯 Backtest Kernel 与分级模拟](adr/0009-research-domain-and-tiered-simulation.md)
+- [ADR-0010：基于依赖图的构建影响与生产工件隔离](adr/0010-build-impact-and-artifact-isolation.md)
+- [ADR-0011：分层运行快照与完整决策上下文](adr/0011-layered-runtime-snapshots-and-decision-context.md)
+- [ADR-0012：多租户私有流连接管理与容量分阶段](adr/0012-multi-tenant-private-stream-management.md)

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# 架构防腐检查器。只读:解析 cargo metadata、静态扫描源码、比对 legacy allowlist 基线。
+# 不依赖任何生产 crate,不进 core-runtime 镜像。
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+toml = "0.8"

--- a/xtask/src/baseline.rs
+++ b/xtask/src/baseline.rs
@@ -1,0 +1,47 @@
+//! 读取 legacy-allowlist.toml 冻结基线。
+
+use serde::Deserialize;
+use std::path::Path;
+
+/// legacy-allowlist.toml 的最小反序列化视图(只取 ratchet 需要的字段)。
+#[derive(Debug, Clone, Deserialize)]
+pub struct Baseline {
+    pub architecture_baseline_git_sha: String,
+    #[serde(default)]
+    pub dependency_violation: Vec<DependencyViolation>,
+    #[serde(default)]
+    pub legacy_path: Vec<LegacyPath>,
+    pub baseline_counts: BaselineCounts,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DependencyViolation {
+    pub id: String,
+    pub edge: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct LegacyPath {
+    pub id: String,
+    pub path: String,
+    #[serde(default)]
+    pub path_also: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BaselineCounts {
+    pub dependency_violations: usize,
+    pub legacy_paths: usize,
+    pub cross_db_direct: usize,
+}
+
+impl Baseline {
+    /// 从 workspace 根相对路径加载。
+    pub fn load(workspace_root: &Path) -> Result<Self, String> {
+        let path = workspace_root
+            .join("docs/architecture/migrations/baseline-2026-07/legacy-allowlist.toml");
+        let text = std::fs::read_to_string(&path)
+            .map_err(|e| format!("读取基线失败 {}: {e}", path.display()))?;
+        toml::from_str(&text).map_err(|e| format!("解析基线 TOML 失败: {e}"))
+    }
+}

--- a/xtask/src/checks.rs
+++ b/xtask/src/checks.rs
@@ -1,0 +1,383 @@
+//! 各架构检查器实现 + ratchet 汇总。
+
+use crate::baseline::Baseline;
+use crate::model::{CheckResult, Outcome, Violation};
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// 定位 workspace 根:从当前可执行目录向上找含 `crates/` 与根 Cargo.toml 的目录。
+/// xtask 由 `cargo xtask` 在 workspace 根启动,CARGO_MANIFEST_DIR 指向 xtask/,取其父。
+fn workspace_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR = <root>/xtask
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
+    let p = Path::new(&manifest);
+    p.parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| p.to_path_buf())
+}
+
+/// 运行全部检查并做 ratchet 判定。
+pub fn run_arch_check() -> Result<Outcome, String> {
+    let root = workspace_root();
+    let baseline = Baseline::load(&root)?;
+
+    let mut checks = Vec::new();
+    checks.push(check_dependency_direction(&root)?);
+    checks.push(check_cross_db_direct(&root)?);
+    checks.push(check_legacy_paths(&root)?);
+    let (size_check, hard_size_failures) = check_file_size(&root)?;
+    checks.push(size_check);
+
+    // ratchet:把每条违规按 baseline_id 是否命中划分。
+    let mut new_violations = Vec::new();
+    let baseline_ids: BTreeSet<String> = baseline
+        .dependency_violation
+        .iter()
+        .map(|v| v.id.clone())
+        .chain(baseline.legacy_path.iter().map(|v| v.id.clone()))
+        .collect();
+    let mut seen_ids: BTreeSet<String> = BTreeSet::new();
+
+    for check in &checks {
+        for v in &check.violations {
+            match &v.baseline_id {
+                Some(id) => {
+                    seen_ids.insert(id.clone());
+                }
+                None => new_violations.push(v.clone()),
+            }
+        }
+    }
+
+    // 已消除的基线违规 = 基线登记了但本次没再出现的 id。
+    let resolved_baseline_ids: Vec<String> = baseline_ids.difference(&seen_ids).cloned().collect();
+
+    // 基线漂移提示:冻结 sha 与当前 HEAD 不同,说明代码已推进,基线可能需复核。
+    // 仅提示不失败(违规数才是 ratchet 判据)。同时用聚合计数交叉校验基线自洽。
+    if let Some(head) = current_git_head(&root) {
+        if head != baseline.architecture_baseline_git_sha {
+            eprintln!(
+                "提示: 基线冻结 sha ({}) 与当前 HEAD ({}) 不同,若架构有变动请复核 legacy-allowlist.toml",
+                &baseline.architecture_baseline_git_sha[..12.min(baseline.architecture_baseline_git_sha.len())],
+                &head[..12.min(head.len())]
+            );
+        }
+    }
+    let counts = &baseline.baseline_counts;
+    let declared = counts.dependency_violations + counts.legacy_paths + counts.cross_db_direct;
+    let registered = baseline.dependency_violation.len() + baseline.legacy_path.len();
+    if declared != registered + counts.cross_db_direct {
+        eprintln!(
+            "提示: baseline_counts 聚合({declared}) 与登记条目({registered} + cross_db {}) 不一致,请核对 legacy-allowlist.toml",
+            counts.cross_db_direct
+        );
+    }
+
+    Ok(Outcome {
+        checks,
+        new_violations,
+        resolved_baseline_ids,
+        hard_size_failures,
+    })
+}
+
+/// 检查 1:依赖方向。解析 cargo metadata 的 workspace 内 crate 依赖边,
+/// 比对允许的分层方向;已知 legacy 违规边(V1/V2)标记 baseline_id 不计新增。
+fn check_dependency_direction(root: &Path) -> Result<CheckResult, String> {
+    let mut result = CheckResult::new("dependency-direction");
+    let baseline = Baseline::load(root)?;
+
+    let meta = cargo_metadata(root)?;
+    let ws_members = meta.workspace_member_names();
+    let edges = meta.workspace_internal_edges(&ws_members);
+
+    // 允许的依赖分层:值越小越靠叶子;禁止低层依赖高层(反向)。
+    // 依据 dependency-graph.md §3 分层。owner-agnostic 层(analytics)不得依赖业务层。
+    let layer = |name: &str| -> i32 {
+        match name {
+            "rust-quant-common" | "rust-quant-domain" => 0,
+            "rust-quant-core" | "rust-quant-trading" => 1,
+            "rust-quant-market" | "rust-quant-infrastructure" => 2,
+            "rust-quant-indicators" | "rust-quant-risk" | "rust-quant-analytics" => 3,
+            "rust-quant-strategies" => 4,
+            "rust-quant-execution" => 5,
+            "rust-quant-services" => 6,
+            "rust-quant-orchestration" => 7,
+            "rust-quant-cli" => 8,
+            _ => -1,
+        }
+    };
+
+    // legacy 基线边集合(规范化为 "a -> b" 判定用)。
+    let baseline_edge_ids: Vec<(String, String)> = baseline
+        .dependency_violation
+        .iter()
+        .map(|v| (v.id.clone(), v.edge.clone()))
+        .collect();
+
+    for (from, to) in &edges {
+        let (lf, lt) = (layer(from), layer(to));
+        if lf < 0 || lt < 0 {
+            continue; // xtask 或外部 crate,跳过
+        }
+        // 违规:依赖了同层或更高层(lt >= lf 表示 to 不比 from 更靠叶子)。
+        if lt >= lf {
+            let baseline_id = match_baseline_edge(&baseline_edge_ids, from, to);
+            result.violations.push(Violation {
+                category: "dependency-direction".into(),
+                detail: format!("{from}(层{lf}) 依赖 {to}(层{lt}),违反叶->根方向"),
+                location: format!("{from} -> {to}"),
+                baseline_id,
+            });
+        }
+    }
+
+    // V2:execution 依赖 strategies/indicators 是耦合方向异常(顺向层次抓不到)。
+    // 显式判定:execution 存在到 strategies 或 indicators 的边即为该基线违规仍存在。
+    let exec_bad = edges.iter().any(|(f, t)| {
+        f == "rust-quant-execution"
+            && (t == "rust-quant-strategies" || t == "rust-quant-indicators")
+    });
+    if exec_bad {
+        let id = baseline_edge_ids
+            .iter()
+            .find(|(_, e)| e.to_lowercase().starts_with("execution"))
+            .map(|(id, _)| id.clone());
+        result.violations.push(Violation {
+            category: "dependency-direction".into(),
+            detail: "execution 反向依赖 strategies/indicators(应经 domain api)".into(),
+            location: "execution -> {strategies, indicators}".into(),
+            baseline_id: id,
+        });
+    }
+
+    Ok(result)
+}
+
+/// 把 metadata 的 crate 名(rust-quant-analytics)与基线 edge("analytics -> strategies")对上。
+fn match_baseline_edge(baseline: &[(String, String)], from: &str, to: &str) -> Option<String> {
+    let short = |n: &str| n.trim_start_matches("rust-quant-").to_string();
+    let (sf, st) = (short(from), short(to));
+    for (id, edge) in baseline {
+        // edge 形如 "analytics -> strategies" 或 "execution -> {strategies, indicators}(...)"
+        let lower = edge.to_lowercase();
+        if let Some((left, right)) = lower.split_once("->") {
+            let left = left.trim();
+            if left == sf && right.contains(&st) {
+                return Some(id.clone());
+            }
+        }
+    }
+    None
+}
+
+/// cargo metadata 的最小视图。
+struct Metadata {
+    json: serde_json::Value,
+}
+
+impl Metadata {
+    /// workspace 成员的 package 名集合。
+    fn workspace_member_names(&self) -> BTreeSet<String> {
+        let ids: BTreeSet<&str> = self.json["workspace_members"]
+            .as_array()
+            .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
+            .unwrap_or_default();
+        self.json["packages"]
+            .as_array()
+            .map(|pkgs| {
+                pkgs.iter()
+                    .filter(|p| p["id"].as_str().map(|id| ids.contains(id)).unwrap_or(false))
+                    .filter_map(|p| p["name"].as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// workspace 内部依赖边 (from, to),只保留两端都是成员的边。
+    fn workspace_internal_edges(&self, members: &BTreeSet<String>) -> Vec<(String, String)> {
+        let mut edges = Vec::new();
+        if let Some(pkgs) = self.json["packages"].as_array() {
+            for p in pkgs {
+                let Some(name) = p["name"].as_str() else {
+                    continue;
+                };
+                if !members.contains(name) {
+                    continue;
+                }
+                if let Some(deps) = p["dependencies"].as_array() {
+                    for d in deps {
+                        let Some(dep_name) = d["name"].as_str() else {
+                            continue;
+                        };
+                        if members.contains(dep_name) && dep_name != name {
+                            edges.push((name.to_string(), dep_name.to_string()));
+                        }
+                    }
+                }
+            }
+        }
+        edges
+    }
+}
+
+/// 调用 cargo metadata --no-deps。
+fn cargo_metadata(root: &Path) -> Result<Metadata, String> {
+    let out = Command::new(std::env::var("CARGO").unwrap_or_else(|_| "cargo".into()))
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .current_dir(root)
+        .output()
+        .map_err(|e| format!("执行 cargo metadata 失败: {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "cargo metadata 退出码非零: {}",
+            String::from_utf8_lossy(&out.stderr)
+        ));
+    }
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout)
+        .map_err(|e| format!("解析 cargo metadata JSON 失败: {e}"))?;
+    Ok(Metadata { json })
+}
+
+/// 读当前 git HEAD sha(失败返回 None,不影响检查)。
+fn current_git_head(root: &Path) -> Option<String> {
+    let out = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(root)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// 检查 2:跨库直连禁令(dependency-rules §13-1/2 精神)。
+/// 静态扫描 crates/ 下源码,禁止新增直连 quant_web/quant_news 的 DB 连接。
+/// 基线为 0(已 HTTP 化);当前 quant_web 只经 execution_task_client 的 HTTP 调用,
+/// quant_core DB 单例有 URL 门禁,故不应有匹配。任何匹配都是新增违规。
+fn check_cross_db_direct(root: &Path) -> Result<CheckResult, String> {
+    let mut result = CheckResult::new("cross-db-direct");
+    // 直连另一库的真实特征是:连接串里出现另一库的 URL 路径字面量(`/quant_web`、`/quant_news`)。
+    // 仅文件里提到库名(注释、门禁校验测试名如 quant_core_..._rejects_quant_web_fallback)不算直连,
+    // 且 quant_web 的正当访问已 HTTP 化(execution_task_client)。基线为 0,任何匹配都是新增违规。
+    let crates_dir = root.join("crates");
+    let mut files = Vec::new();
+    collect_rs_files(&crates_dir, &mut files);
+    for f in &files {
+        let Ok(text) = std::fs::read_to_string(f) else {
+            continue;
+        };
+        // sqlx_pool 是受控 core DB 单例入口(URL 门禁在此实现,含 reject 逻辑),豁免。
+        if f.ends_with("sqlx_pool.rs") {
+            continue;
+        }
+        // 排除测试:tests/ 目录、文件名含 test、含 #[cfg(test)] 的文件。测试 fixture / 健康检查
+        // 里出现别库 URL 是合法的(路由校验、env 设置),不是生产直连。静态扫描无法区分二者,
+        // 故只扫生产源码。运行时真实防护由 sqlx_pool.rs 的 URL 门禁(有测试覆盖)提供。
+        let path_str = rel(root, f);
+        let is_test = path_str.contains("/tests/")
+            || path_str.contains("tests/")
+            || f.file_name()
+                .and_then(|n| n.to_str())
+                .map(|n| n.contains("test"))
+                .unwrap_or(false)
+            || text.contains("#[cfg(test)]");
+        if is_test {
+            continue;
+        }
+        for (lineno, line) in text.lines().enumerate() {
+            // 连接串路径字面量:postgres://.../quant_web 或 .../quant_news
+            let hits_web = line.contains("/quant_web");
+            let hits_news = line.contains("/quant_news");
+            if (hits_web || hits_news)
+                && (line.contains("postgres://") || line.contains("postgresql://"))
+            {
+                let target = if hits_web { "quant_web" } else { "quant_news" };
+                result.violations.push(Violation {
+                    category: "cross-db-direct".into(),
+                    detail: format!("连接串直连 {target} 数据库(应经 owner HTTP API)"),
+                    location: format!("{}:{}", rel(root, f), lineno + 1),
+                    baseline_id: None,
+                });
+            }
+        }
+    }
+    Ok(result)
+}
+
+/// 检查 2b:legacy signed read-only 路径存续核对(基线 V3/V4/V5)。
+/// 这些文件是登记的 legacy 直读路径;只要文件还在,就是"基线内违规仍存在"(seen)。
+/// 文件被删除(收敛完成)时不再 seen,ratchet 将其判为已消除。不检测新增(新增由依赖方向 + review 覆盖)。
+fn check_legacy_paths(root: &Path) -> Result<CheckResult, String> {
+    let mut result = CheckResult::new("legacy-signed-read-only");
+    let baseline = Baseline::load(root)?;
+    for lp in &baseline.legacy_path {
+        let mut paths = vec![lp.path.clone()];
+        if let Some(also) = &lp.path_also {
+            paths.push(also.clone());
+        }
+        // 只要任一登记路径仍存在,视为该基线违规仍在。
+        let still_present = paths.iter().any(|p| root.join(p).exists());
+        if still_present {
+            result.violations.push(Violation {
+                category: "legacy-signed-read-only".into(),
+                detail: format!("legacy 账户直读路径仍存在(基线 {})", lp.id),
+                location: paths.join(", "),
+                baseline_id: Some(lp.id.clone()),
+            });
+        }
+    }
+    Ok(result)
+}
+
+/// 检查 3:文件行数闸门(dependency-rules §13-10)。
+/// 复用根 scripts/dev/check_code_file_line_limit.sh 的阈值:1000 WARN / 2000 硬失败。
+/// 硬失败单独返回,进入 Outcome.hard_size_failures 直接导致 FAIL。
+fn check_file_size(root: &Path) -> Result<(CheckResult, Vec<String>), String> {
+    let mut result = CheckResult::new("file-size");
+    let mut hard = Vec::new();
+    const WARN: usize = 1000;
+    const HARD: usize = 2000;
+    let crates_dir = root.join("crates");
+    let mut files = Vec::new();
+    collect_rs_files(&crates_dir, &mut files);
+    for f in &files {
+        let Ok(text) = std::fs::read_to_string(f) else {
+            continue;
+        };
+        let lines = text.lines().count();
+        if lines > HARD {
+            hard.push(format!("{} lines={lines} hard_limit={HARD}", rel(root, f)));
+        } else if lines > WARN {
+            result
+                .warnings
+                .push(format!("{} lines={lines} target={WARN}", rel(root, f)));
+        }
+    }
+    Ok((result, hard))
+}
+
+/// 递归收集 .rs 文件,跳过 target/。
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for e in entries.flatten() {
+        let p = e.path();
+        if p.is_dir() {
+            if p.file_name().map(|n| n == "target").unwrap_or(false) {
+                continue;
+            }
+            collect_rs_files(&p, out);
+        } else if p.extension().map(|x| x == "rs").unwrap_or(false) {
+            out.push(p);
+        }
+    }
+}
+
+/// 相对 workspace 根的可读路径。
+fn rel(root: &Path, f: &Path) -> String {
+    f.strip_prefix(root).unwrap_or(f).display().to_string()
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,43 @@
+//! 架构防腐检查器(只读)。
+//!
+//! 用法:`cargo xtask arch-check [--json]`
+//!
+//! 把 dependency-rules.md §13 中当前可静态检查的规则落地为检查器,并按
+//! `docs/architecture/migrations/baseline-2026-07/legacy-allowlist.toml` 冻结的
+//! legacy 违规基线做 ratchet:运行违规数 > 基线即 FAIL,<= 基线通过。
+//!
+//! 本工具不修改任何源码,不做自动修复,不进生产依赖图(见 xtask/Cargo.toml)。
+
+mod baseline;
+mod checks;
+mod model;
+mod report;
+
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let cmd = args.first().map(String::as_str).unwrap_or("arch-check");
+    let json = args.iter().any(|a| a == "--json");
+
+    match cmd {
+        "arch-check" => match checks::run_arch_check() {
+            Ok(outcome) => {
+                report::print(&outcome, json);
+                if outcome.failed() {
+                    ExitCode::FAILURE
+                } else {
+                    ExitCode::SUCCESS
+                }
+            }
+            Err(e) => {
+                eprintln!("xtask arch-check 内部错误: {e}");
+                ExitCode::FAILURE
+            }
+        },
+        other => {
+            eprintln!("未知子命令: {other}。可用: arch-check [--json]");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/xtask/src/model.rs
+++ b/xtask/src/model.rs
@@ -1,0 +1,54 @@
+//! arch-check 的结果数据模型。
+
+use serde::Serialize;
+
+/// 单条违规发现。
+#[derive(Debug, Clone, Serialize)]
+pub struct Violation {
+    /// 规则类别 slug(dependency / cross-db / file-size / ...)
+    pub category: String,
+    /// 人读描述
+    pub detail: String,
+    /// 相关位置(crate 名、边、文件路径)
+    pub location: String,
+    /// 若匹配到已登记 legacy 基线,填其 id(V1..);新增违规为 None
+    pub baseline_id: Option<String>,
+}
+
+/// 单个检查器的结果。
+#[derive(Debug, Clone, Serialize)]
+pub struct CheckResult {
+    pub name: String,
+    /// 本检查器发现的全部违规(含基线内的)
+    pub violations: Vec<Violation>,
+    /// 仅告警、不计入 ratchet 的项(如行数 WARN)
+    pub warnings: Vec<String>,
+}
+
+impl CheckResult {
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            violations: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+}
+
+/// arch-check 整体结果 + ratchet 判定。
+#[derive(Debug, Clone, Serialize)]
+pub struct Outcome {
+    pub checks: Vec<CheckResult>,
+    /// 新增(基线外)违规:导致 FAIL
+    pub new_violations: Vec<Violation>,
+    /// 已消除的基线违规(违规数下降,好事,仅提示)
+    pub resolved_baseline_ids: Vec<String>,
+    /// 硬失败:文件超过 2000 行硬上限
+    pub hard_size_failures: Vec<String>,
+}
+
+impl Outcome {
+    pub fn failed(&self) -> bool {
+        !self.new_violations.is_empty() || !self.hard_size_failures.is_empty()
+    }
+}

--- a/xtask/src/report.rs
+++ b/xtask/src/report.rs
@@ -1,0 +1,60 @@
+//! arch-check 结果输出:人读摘要 + 可选 JSON。
+
+use crate::model::Outcome;
+
+pub fn print(outcome: &Outcome, json: bool) {
+    if json {
+        match serde_json::to_string_pretty(outcome) {
+            Ok(s) => println!("{s}"),
+            Err(e) => eprintln!("序列化 JSON 失败: {e}"),
+        }
+        return;
+    }
+
+    println!("== cargo xtask arch-check ==");
+    for c in &outcome.checks {
+        let total = c.violations.len();
+        let baseline_hits = c
+            .violations
+            .iter()
+            .filter(|v| v.baseline_id.is_some())
+            .count();
+        let new_hits = total - baseline_hits;
+        println!(
+            "[{}] 违规 {total}(基线内 {baseline_hits} / 新增 {new_hits}),告警 {}",
+            c.name,
+            c.warnings.len()
+        );
+        for w in &c.warnings {
+            println!("    WARN  {w}");
+        }
+    }
+
+    if !outcome.resolved_baseline_ids.is_empty() {
+        println!(
+            "\n已消除的基线违规(违规数下降): {}",
+            outcome.resolved_baseline_ids.join(", ")
+        );
+    }
+
+    if !outcome.new_violations.is_empty() {
+        println!("\n新增违规(禁止,导致 FAIL):");
+        for v in &outcome.new_violations {
+            println!("    FAIL  [{}] {} @ {}", v.category, v.detail, v.location);
+        }
+    }
+
+    if !outcome.hard_size_failures.is_empty() {
+        println!("\n文件行数硬失败(>2000 行):");
+        for f in &outcome.hard_size_failures {
+            println!("    FAIL  {f}");
+        }
+    }
+
+    println!();
+    if outcome.failed() {
+        println!("结果: FAIL");
+    } else {
+        println!("结果: PASS(违规数未超过冻结基线)");
+    }
+}


### PR DESCRIPTION
阶段0基线冻结 + 阶段1 xtask arch-check 防腐 ratchet:
- 清理悬空 rust-quant-ai-analysis 依赖;新增 xtask 只读架构检查器 (依赖方向/跨库直连/行数闸门/legacy 路径存续 + ratchet)
- docs/architecture/migrations/baseline-2026-07/:依赖图、Owner Ledger、 运行拓扑、legacy-allowlist 基线冻结(sha 660407f)

目标架构文档增补三批迭代坏习惯防线:
- §10.1 类型边界(无类型 JSON/SDK DTO 只在 Adapter)
- §10.2 错误处理(热路径禁 panic/禁压平错误)
- §10.3 数据/迁移/配置/凭证纪律
- §12 增补对应 CI 门禁

技能 rust-quant-architecture:新增三批坏习惯表(结构6类/工程纪律7类/
基础设施运维8类)与研究-生产隔离规则,更新自查流程